### PR TITLE
PW-1556 execute notifications

### DIFF
--- a/adyen.php
+++ b/adyen.php
@@ -29,21 +29,16 @@ if (!defined('_PS_VERSION_')) {
 
 class Adyen extends \PaymentModule
 {
-    const TEST = 'test';
-    const LIVE = 'live';
-    const CHECKOUT_COMPONENT_JS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.js';
-    const CHECKOUT_COMPONENT_JS_LIVE = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.0.0/adyen.js';
-    const CHECKOUT_COMPONENT_CSS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css';
-    const CHECKOUT_COMPONENT_CSS_LIVE = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css';
-    const VERSION = '1.0.1';
-    const MODULE_NAME = 'adyen-prestashop';
-
-
+    /**
+     * Adyen constructor.
+     *
+     * @throws \Adyen\AdyenException
+     */
     public function __construct()
     {
         $this->name = 'adyen';
         $this->tab = 'payments_gateways';
-        $this->version = self::VERSION;
+        $this->version = \Adyen\PrestaShop\helper\Configuration::VERSION;
         $this->author = 'Adyen';
         $this->bootstrap = true;
         $this->display = 'view';
@@ -80,11 +75,12 @@ class Adyen extends \PaymentModule
 	 */
     public function install()
     {
-
         if (version_compare(_PS_VERSION_, '1.5', '<')) {
             $this->_errors[] = $this->l('Sorry, this module is not compatible with your version.');
             return false;
         }
+
+        $this->updateCronJobToken();
 
         if ($this->helper_data->isPrestashop16()) {
             // Version 1.6 requires a different set of hooks
@@ -99,6 +95,7 @@ class Adyen extends \PaymentModule
                 && $this->registerHook('moduleRoutes')
                 // the table for notifications from Adyen needs to be both in install and upgrade
                 && $this->createAdyenNotificationTable()
+                && $this->installTab()
             ) {
                 return true;
             } else {
@@ -109,6 +106,7 @@ class Adyen extends \PaymentModule
 
         // install hooks for version 1.7 or higher
         return parent::install()
+            && $this->installTab()
             && $this->registerHook('header')
             && $this->registerHook('orderConfirmation')
             && $this->registerHook('paymentOptions')
@@ -119,6 +117,22 @@ class Adyen extends \PaymentModule
             && $this->createAdyenNotificationTable();
     }
 
+    /**
+     * @param string $token
+     * @return bool
+     */
+    public function updateCronJobToken($token = '')
+    {
+        if (empty($token)) {
+            $token = \Tools::encrypt(\Tools::getShopDomainSsl().time());
+        }
+
+        return \Configuration::updateValue('ADYEN_CRONJOB_TOKEN', \Tools::encrypt($token));
+    }
+
+    /**
+     * @return bool
+     */
     public function createAdyenNotificationTable()
     {
         $db = Db::getInstance();
@@ -146,9 +160,7 @@ class Adyen extends \PaymentModule
             KEY `ADYEN_NOTIFICATION_MERCHANT_REFERENCE_EVENT_CODE` (`merchant_reference`,`event_code`)
             ) ENGINE=' . _MYSQL_ENGINE_ . ' AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COMMENT=\'Adyen Notifications\'';
 
-        $db->execute($query);
-
-        return true;
+        return $db->execute($query);
     }
 
     /**
@@ -161,10 +173,45 @@ class Adyen extends \PaymentModule
         // TODO: delete adyen configurations (api-key)
         $db = Db::getInstance();
         /** @noinspection SqlWithoutWhere SqlResolve */
-        $db->execute('DELETE FROM `' . _DB_PREFIX_ . 'adyen_notification`');
         $db->execute('DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'adyen_notification`');
 
-        return parent::uninstall();
+        return parent::uninstall() && $this->uninstallTab();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function installTab()
+    {
+        $tab = new Tab();
+        // invisible tab
+        $tab->id_parent = -1;
+        $tab->active = 1;
+
+        $tab->name = array();
+        foreach (\Language::getLanguages(true) as $lang) {
+            $tab->name[$lang['id_lang']] = 'Adyen Prestashop Cron';
+        }
+
+        $tab->class_name = 'AdminAdyenPrestashopCron';
+        $tab->module = $this->name;
+
+        return $tab->add();
+    }
+
+    /**
+     * @return bool
+     */
+    public function uninstallTab()
+    {
+        $id_tab = (int)\Tab::getIdFromClassName('AdminAdyenPrestashopCron');
+
+        if ($id_tab) {
+            $tab = new \Tab($id_tab);
+            return $tab->delete();
+        }
+
+        return false;
     }
 
 
@@ -183,10 +230,10 @@ class Adyen extends \PaymentModule
             $notification_username = (string)\Tools::getValue('ADYEN_NOTI_USERNAME');
             $notification_password = (string)\Tools::getValue('ADYEN_NOTI_PASSWORD');
             $notification_hmac = (string)\Tools::getValue('ADYEN_NOTI_HMAC');
+            $cron_job_token = \Tools::getValue('ADYEN_CRONJOB_TOKEN');
             $api_key_test = \Tools::getValue('ADYEN_APIKEY_TEST');
             $api_key_live = \Tools::getValue('ADYEN_APIKEY_LIVE');
             $live_endpoint_url_prefix = (string)\Tools::getValue('ADYEN_LIVE_ENDPOINT_URL_PREFIX');
-
 
             // validating the input
             if (!$merchant_account || empty($merchant_account) || !\Validate::isGenericName($merchant_account)) {
@@ -201,19 +248,20 @@ class Adyen extends \PaymentModule
                 $output .= $this->displayError($this->l('Invalid Configuration value for Notification Password'));
             }
 
-            if (empty($notification_hmac) || !\Validate::isGenericName($notification_hmac)) {
-                $output .= $this->displayError($this->l('Invalid Configuration value for Notification HMAC Key'));
-            }
-
-
             if ($output == null) {
 
                 \Configuration::updateValue('ADYEN_MERCHANT_ACCOUNT', $merchant_account);
                 \Configuration::updateValue('ADYEN_MODE', $mode);
                 \Configuration::updateValue('ADYEN_NOTI_USERNAME', $notification_username);
                 \Configuration::updateValue('ADYEN_NOTI_PASSWORD', $notification_password);
-                \Configuration::updateValue('ADYEN_NOTI_HMAC', $notification_hmac);
                 \Configuration::updateValue('ADYEN_LIVE_ENDPOINT_URL_PREFIX', $live_endpoint_url_prefix);
+
+                if (!empty($notification_hmac)) {
+                    \Configuration::updateValue('ADYEN_NOTI_HMAC', $notification_hmac);
+                }
+                if (!empty($cron_job_token)) {
+                    \Configuration::updateValue('ADYEN_CRONJOB_TOKEN', \Tools::encrypt($cron_job_token));
+                }
                 if (!empty($api_key_test)) {
                     \Configuration::updateValue('ADYEN_APIKEY_TEST', $this->helper_data->encrypt($api_key_test));
                 }
@@ -294,12 +342,20 @@ class Adyen extends \PaymentModule
                     'hint' => $this->l('Must correspond to the notification password in the Adyen Backoffice under Settings => Notifications')
                 ),
                 array(
-                    'type' => 'text',
+                    'type' => 'password',
                     'label' => $this->l('HMAC key for notifications'),
                     'name' => 'ADYEN_NOTI_HMAC',
                     'size' => 20,
-                    'required' => true,
+                    'required' => false,
                     'hint' => $this->l('Must correspond to the notification HMAC Key in the Adyen Backoffice under Settings => Notifications => Additional Settings => HMAC Key (HEX Encoded)')
+                ),
+                array(
+                    'type' => 'password',
+                    'label' => $this->l('Secure token for cron job'),
+                    'name' => 'ADYEN_CRONJOB_TOKEN',
+                    'size' => 20,
+                    'required' => false,
+                    'hint' => $this->l('Your adyen cron job processor\'s url includes this secure token . Your URL looks like: ***Your store url***/admin-dev/index.php?fc=module&controller=AdminAdyenPrestashopCron&token=***This token***')
                 ),
                 array(
                     'type' => 'password',
@@ -366,7 +422,8 @@ class Adyen extends \PaymentModule
             $mode = (string)\Tools::getValue('ADYEN_MODE');
             $notification_username = (string)\Tools::getValue('ADYEN_NOTI_USERNAME');
             $notification_password = (string)\Tools::getValue('ADYEN_NOTI_PASSWORD');
-            $notification_HMAC = (string)\Tools::getValue('ADYEN_NOTI_HMAC');
+            $notification_HMAC = $this->hashing->hash(\Tools::getValue('ADYEN_NOTI_HMAC', _COOKIE_KEY_));
+            $cron_job_token = $this->hashing->hash(\Tools::getValue('ADYEN_CRONJOB_TOKEN', _COOKIE_KEY_));
             $live_endpoint_url_prefix = (string)\Tools::getValue('ADYEN_LIVE_ENDPOINT_URL_PREFIX');
             $api_key_test = $this->hashing->hash(\Tools::getValue('ADYEN_APIKEY_TEST'), _COOKIE_KEY_);
             $api_key_live = $this->hashing->hash(\Tools::getValue('ADYEN_APIKEY_LIVE'), _COOKIE_KEY_);
@@ -375,7 +432,8 @@ class Adyen extends \PaymentModule
             $mode = \Configuration::get('ADYEN_MODE');
             $notification_username = \Configuration::get('ADYEN_NOTI_USERNAME');
             $notification_password = \Configuration::get('ADYEN_NOTI_PASSWORD');
-            $notification_HMAC = \Configuration::get('ADYEN_NOTI_HMAC');
+            $notification_HMAC = $this->hashing->hash(\Configuration::get('ADYEN_NOTI_HMAC'), _COOKIE_KEY_);
+            $cron_job_token = $this->hashing->hash(\Configuration::get('ADYEN_CRONJOB_TOKEN'), _COOKIE_KEY_);
             $live_endpoint_url_prefix = \Configuration::get('ADYEN_LIVE_ENDPOINT_URL_PREFIX');
             $api_key_test = $this->hashing->hash(\Configuration::get('ADYEN_APIKEY_TEST'),
                 _COOKIE_KEY_);;
@@ -389,6 +447,7 @@ class Adyen extends \PaymentModule
         $helper->fields_value['ADYEN_NOTI_USERNAME'] = $notification_username;
         $helper->fields_value['ADYEN_NOTI_PASSWORD'] = $notification_password;
         $helper->fields_value['ADYEN_NOTI_HMAC'] = $notification_HMAC;
+        $helper->fields_value['ADYEN_CRONJOB_TOKEN'] = $cron_job_token;
         $helper->fields_value['ADYEN_APIKEY_TEST'] = $api_key_test;
         $helper->fields_value['ADYEN_APIKEY_LIVE'] = $api_key_live;
         $helper->fields_value['ADYEN_LIVE_ENDPOINT_URL_PREFIX'] = $live_endpoint_url_prefix;
@@ -417,13 +476,13 @@ class Adyen extends \PaymentModule
         if ($this->helper_data->isDemoMode()) {
 
             if (version_compare(_PS_VERSION_, '1.7', '<')) {
-                $this->context->controller->addJS(self::CHECKOUT_COMPONENT_JS_TEST);
-                $this->context->controller->addCSS(self::CHECKOUT_COMPONENT_CSS_TEST);
+                $this->context->controller->addJS(\Adyen\PrestaShop\helper\Configuration::CHECKOUT_COMPONENT_JS_TEST);
+                $this->context->controller->addCSS(\Adyen\PrestaShop\helper\Configuration::CHECKOUT_COMPONENT_CSS_TEST);
                 $this->context->controller->addJS($this->_path . 'views/js/threeds2-js-utils.js');
             } else {
                 $this->context->controller->registerJavascript(
                     'component', // Unique ID
-                    self::CHECKOUT_COMPONENT_JS_TEST, // JS path
+                    \Adyen\PrestaShop\helper\Configuration::CHECKOUT_COMPONENT_JS_TEST, // JS path
                     array('server' => 'remote', 'position' => 'bottom', 'priority' => 150) // Arguments
                 );
                 $this->context->controller->registerJavascript(
@@ -433,7 +492,7 @@ class Adyen extends \PaymentModule
                 );
                 $this->context->controller->registerStylesheet(
                     'stylecheckout', // Unique ID
-                    self::CHECKOUT_COMPONENT_CSS_TEST, // CSS path
+                    \Adyen\PrestaShop\helper\Configuration::CHECKOUT_COMPONENT_CSS_TEST, // CSS path
                     array('server' => 'remote', 'position' => 'bottom', 'priority' => 150) // Arguments
                 );
 
@@ -443,13 +502,13 @@ class Adyen extends \PaymentModule
         } else {
 
             if (version_compare(_PS_VERSION_, '1.7', '<')) {
-                $this->context->controller->addJS(self::CHECKOUT_COMPONENT_JS_LIVE);
-                $this->context->controller->addCSS(self::CHECKOUT_COMPONENT_CSS_LIVE);
+                $this->context->controller->addJS(\Adyen\PrestaShop\helper\Configuration::CHECKOUT_COMPONENT_JS_LIVE);
+                $this->context->controller->addCSS(\Adyen\PrestaShop\helper\Configuration::CHECKOUT_COMPONENT_CSS_LIVE);
                 $this->context->controller->addJS($this->_path . 'views/js/threeds2-js-utils.js');
             } else {
                 $this->context->controller->registerJavascript(
                     'component', // Unique ID
-                    self::CHECKOUT_COMPONENT_JS_LIVE, // JS path
+                    \Adyen\PrestaShop\helper\Configuration::CHECKOUT_COMPONENT_JS_LIVE, // JS path
                     array('server' => 'remote', 'position' => 'bottom', 'priority' => 150) // Arguments
                 );
                 $this->context->controller->registerJavascript(
@@ -459,7 +518,7 @@ class Adyen extends \PaymentModule
                 );
                 $this->context->controller->registerStylesheet(
                     'stylecheckout', // Unique ID
-                    self::CHECKOUT_COMPONENT_CSS_LIVE, // CSS path
+                    \Adyen\PrestaShop\helper\Configuration::CHECKOUT_COMPONENT_CSS_LIVE, // CSS path
                     array('server' => 'remote', 'position' => 'bottom', 'priority' => 150) // Arguments
                 );
             }
@@ -567,5 +626,4 @@ class Adyen extends \PaymentModule
     {
         return;
     }
-
 }

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -39,9 +39,8 @@ abstract class FrontController extends \ModuleFrontController
      */
     protected function ajaxRender($value = null, $controller = null, $method = null)
     {
-        $this->ajax = true;
-
         if ($this->helperData->isPrestashop16()) {
+            $this->ajax = true;
             parent::ajaxDie($value, $controller, $method);
         } else {
             parent::ajaxRender($value, $controller, $method);

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -22,7 +22,6 @@
 
 namespace Adyen\PrestaShop\controllers;
 
-
 use PrestaShopException;
 
 abstract class FrontController extends \ModuleFrontController
@@ -40,10 +39,13 @@ abstract class FrontController extends \ModuleFrontController
      */
     protected function ajaxRender($value = null, $controller = null, $method = null)
     {
+        $this->ajax = true;
+
         if ($this->helperData->isPrestashop16()) {
             parent::ajaxDie($value, $controller, $method);
         } else {
             parent::ajaxRender($value, $controller, $method);
+            exit;
         }
     }
 }

--- a/controllers/admin/AdminAdyenPrestashopCronController.php
+++ b/controllers/admin/AdminAdyenPrestashopCronController.php
@@ -34,17 +34,18 @@ class AdminAdyenPrestashopCronController extends \ModuleAdminController
      */
     public function __construct()
     {
-        if (\Tools::encrypt(\Tools::getValue('token')) != \Configuration::get('ADYEN_CRONJOB_TOKEN')) {
-            die('Invalid token');
-        }
-
-        $this->context = \Context::getContext();
 
         $adyenHelperFactory = new \Adyen\PrestaShop\service\helper\DataFactory();
         $this->helperData = $adyenHelperFactory->createAdyenHelperData(
             \Configuration::get('ADYEN_MODE'),
             _COOKIE_KEY_
         );
+
+        if (\Tools::getValue('token') != $this->helperData->decrypt(\Configuration::get('ADYEN_CRONJOB_TOKEN'))) {
+            die('Invalid token');
+        }
+
+        $this->context = \Context::getContext();
 
         parent::__construct();
         $this->postProcess();

--- a/controllers/admin/AdminAdyenPrestashopCronController.php
+++ b/controllers/admin/AdminAdyenPrestashopCronController.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop module
+ *
+ * Copyright (c) 2019 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+class AdminAdyenPrestashopCronController extends \ModuleAdminController
+{
+    /**
+     * @var bool
+     */
+    public $ssl = true;
+
+    /**
+     * AdminAdyenPrestashopCronController constructor.
+     *
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct()
+    {
+        if (\Tools::encrypt(\Tools::getValue('token')) != \Configuration::get('ADYEN_CRONJOB_TOKEN')) {
+            die('Invalid token');
+        }
+
+        $this->context = \Context::getContext();
+
+        $adyenHelperFactory = new \Adyen\PrestaShop\service\helper\DataFactory();
+        $this->helperData = $adyenHelperFactory->createAdyenHelperData(
+            \Configuration::get('ADYEN_MODE'),
+            _COOKIE_KEY_
+        );
+
+        parent::__construct();
+        $this->postProcess();
+        die();
+    }
+
+    /**
+     *
+     */
+    public function postProcess()
+    {
+        $notificationProcessor = new \Adyen\PrestaShop\service\notification\NotificationProcessor(
+            $this->helperData,
+            Db::getInstance()
+
+        );
+        $notificationProcessor->doPostProcess();
+    }
+}

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -13,29 +13,16 @@
  *                               #############
  *                               ############
  *
- * Adyen PrestaShop plugin
+ * Adyen PrestaShop module
  *
  * Copyright (c) 2019 Adyen B.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  */
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
 
-/**
- * This function is automatically called on version upgrades.
- *
- * Version 1.0.1 introduces a database table for notifications from Adyen.
- *
- * @param Adyen $module
- * @return bool
- */
-function upgrade_module_1_0_1($module)
-{
-    $module->createAdyenNotificationTable();
-    $module->updateCronJobToken();
-    $module->installTab();
-    return true;
-}
+header("Location: ../");
+exit;

--- a/controllers/front/Notifications.php
+++ b/controllers/front/Notifications.php
@@ -21,7 +21,7 @@
  */
 
 use Adyen\PrestaShop\controllers\FrontController;
-use Adyen\PrestaShop\service\NotificationReceiver;
+use Adyen\PrestaShop\service\notification\NotificationReceiver;
 
 class AdyenNotificationsModuleFrontController extends FrontController
 {
@@ -80,7 +80,4 @@ class AdyenNotificationsModuleFrontController extends FrontController
             die(json_encode(['success' => false, 'message' => $e->getMessage()]));
         }
     }
-
-
-
 }

--- a/controllers/front/Notifications.php
+++ b/controllers/front/Notifications.php
@@ -21,7 +21,7 @@
  */
 
 use Adyen\PrestaShop\controllers\FrontController;
-use Adyen\PrestaShop\service\NotificationProcessor;
+use Adyen\PrestaShop\service\NotificationReceiver;
 
 class AdyenNotificationsModuleFrontController extends FrontController
 {
@@ -40,13 +40,12 @@ class AdyenNotificationsModuleFrontController extends FrontController
         );
     }
 
-
     /**
      * @throws PrestaShopException
      */
     public function postProcess()
     {
-        $notificationProcessor = new NotificationProcessor(
+        $notificationReceiver = new NotificationReceiver(
             $this->helperData,
             new \Adyen\Util\HmacSignature(),
             Configuration::get('ADYEN_NOTI_HMAC'),
@@ -56,7 +55,7 @@ class AdyenNotificationsModuleFrontController extends FrontController
             Db::getInstance()
         );
         try {
-            die($notificationProcessor->doPostProcess(
+            die($notificationReceiver->doPostProcess(
                 json_decode(file_get_contents('php://input'), true))
             );
         } catch (\Adyen\PrestaShop\service\notification\AuthenticationException $e) {

--- a/controllers/front/Payment.php
+++ b/controllers/front/Payment.php
@@ -111,10 +111,10 @@ class AdyenPaymentModuleFrontController extends \Adyen\PrestaShop\controllers\Fr
 
         if (!\Validate::isLoadedObject($customer)) {
             if (empty($_REQUEST['isAjax'])) {
-                \Tools::redirect($this->context->link->getPageLink('order', $this->ssl) . '?step=1');
+                \Tools::redirect($this->context->link->getPageLink('order', $this->ssl, null, 'step=1'));
             } else {
                 $this->ajaxRender($this->helperData->buildControllerResponseJson('redirect',
-                    ['redirectUrl' => $this->context->link->getPageLink('order', $this->ssl) . '?step=1']));
+                    ['redirectUrl' => $this->context->link->getPageLink('order', $this->ssl, null, 'step=1')]));
             }
         }
 
@@ -159,10 +159,10 @@ class AdyenPaymentModuleFrontController extends \Adyen\PrestaShop\controllers\Fr
 
                 // Since this controller handles ajax and non ajax form submissions as well, both server side and client side redirects needs to be handled based on the isAjax request parameter
                 if (empty($_REQUEST['isAjax'])) {
-                    \Tools::redirect($this->context->link->getPageLink('order-confirmation', $this->ssl) . '?id_cart=' . $cart->id . '&id_module=' . $this->module->id . '&id_order=' . $this->module->currentOrder . '&key=' . $customer->secure_key);
+                    \Tools::redirect($this->context->link->getPageLink('order-confirmation', $this->ssl, null, 'id_cart=' . $cart->id . '&id_module=' . $this->module->id . '&id_order=' . $this->module->currentOrder . '&key=' . $customer->secure_key));
                 } else {
                     $this->ajaxRender($this->helperData->buildControllerResponseJson('redirect',
-                        ['redirectUrl' => $this->context->link->getPageLink('order-confirmation', $this->ssl) . '?id_cart=' . $cart->id . '&id_module=' . $this->module->id . '&id_order=' . $this->module->currentOrder . '&key=' . $customer->secure_key]));
+                        ['redirectUrl' => $this->context->link->getPageLink('order-confirmation', $this->ssl, null, 'id_cart=' . $cart->id . '&id_module=' . $this->module->id . '&id_order=' . $this->module->currentOrder . '&key=' . $customer->secure_key)]));
                 }
 
                 break;

--- a/controllers/front/ThreeDSProcess.php
+++ b/controllers/front/ThreeDSProcess.php
@@ -49,9 +49,6 @@ class AdyenThreeDSProcessModuleFrontController extends \Adyen\PrestaShop\control
      */
     public function postProcess()
     {
-        // Currently this controller only handles ajax requests
-        $this->ajax = true;
-
         $payload = $_REQUEST;
 
         if (!empty($_SESSION['paymentData'])) {
@@ -66,7 +63,6 @@ class AdyenThreeDSProcessModuleFrontController extends \Adyen\PrestaShop\control
                     'message' => "3D secure 2.0 failed, payment data not found"
                 ]
             ));
-            return;
         }
 
         // Depends on the component's response we send a fingerprint or the challenge result

--- a/controllers/front/Validate3d.php
+++ b/controllers/front/Validate3d.php
@@ -53,7 +53,7 @@ class AdyenValidate3dModuleFrontController extends \Adyen\PrestaShop\controllers
             ]
         ];
 
-        $client->setAdyenPaymentSource(\Adyen\PrestaShop\helper\Configuration::MODULE_NAME, \Adyen\PrestaShop\helper\Configuration::VERSION);
+        $client->setAdyenPaymentSource(\Adyen\PrestaShop\service\Configuration::MODULE_NAME, \Adyen\PrestaShop\service\Configuration::VERSION);
 
         try {
             $client = $this->helperData->initializeAdyenClient();
@@ -91,7 +91,7 @@ class AdyenValidate3dModuleFrontController extends \Adyen\PrestaShop\controllers
                         $payment[0]->save();
                     }
                 }
-                \Tools::redirect($this->context->link->getPageLink('order-confirmation', $this->ssl) . '?id_cart=' . $cart->id . '&id_module=' . $this->module->id . '&id_order=' . $this->module->currentOrder . '&key=' . $customer->secure_key);
+                \Tools::redirect($this->context->link->getPageLink('order-confirmation', $this->ssl, null, 'id_cart=' . $cart->id . '&id_module=' . $this->module->id . '&id_order=' . $this->module->currentOrder . '&key=' . $customer->secure_key));
                 break;
             case 'Refused':
                 // create new cart from the current cart

--- a/controllers/front/Validate3d.php
+++ b/controllers/front/Validate3d.php
@@ -53,7 +53,7 @@ class AdyenValidate3dModuleFrontController extends \Adyen\PrestaShop\controllers
             ]
         ];
 
-        $client->setAdyenPaymentSource(\Adyen::MODULE_NAME, \Adyen::VERSION);
+        $client->setAdyenPaymentSource(\Adyen\PrestaShop\helper\Configuration::MODULE_NAME, \Adyen\PrestaShop\helper\Configuration::VERSION);
 
         try {
             $client = $this->helperData->initializeAdyenClient();
@@ -61,8 +61,10 @@ class AdyenValidate3dModuleFrontController extends \Adyen\PrestaShop\controllers
             $service = new \Adyen\Service\Checkout($client);
             $response = $service->paymentsDetails($request);
         } catch (\Adyen\AdyenException $e) {
-            $response['error'] = $e->getMessage();
-            $this->helperData->adyenLogger()->logError("exception: " . $e->getMessage());
+            $this->helperData->adyenLogger()->logError("Error during validate3d paymentsDetails call: exception: " . $e->getMessage());
+            $this->ajaxRender(
+                $this->helperData->buildControllerResponseJson('error', ['message' => "Something went wrong. Please choose another payment method."])
+            );
         }
         $this->helperData->adyenLogger()->logDebug("result: " . json_encode($response));
         $currency = $this->context->currency;
@@ -89,7 +91,7 @@ class AdyenValidate3dModuleFrontController extends \Adyen\PrestaShop\controllers
                         $payment[0]->save();
                     }
                 }
-                \Tools::redirect('index.php?controller=order-confirmation&id_cart=' . $cart->id . '&id_module=' . $this->module->id . '&id_order=' . $this->module->currentOrder . '&key=' . $customer->secure_key);
+                \Tools::redirect($this->context->link->getPageLink('order-confirmation', $this->ssl) . '?id_cart=' . $cart->id . '&id_module=' . $this->module->id . '&id_order=' . $this->module->currentOrder . '&key=' . $customer->secure_key);
                 break;
             case 'Refused':
                 // create new cart from the current cart

--- a/helper/Configuration.php
+++ b/helper/Configuration.php
@@ -13,29 +13,21 @@
  *                               #############
  *                               ############
  *
- * Adyen PrestaShop plugin
+ * Adyen PrestaShop module
  *
  * Copyright (c) 2019 Adyen B.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  */
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
+namespace Adyen\PrestaShop\helper;
 
-/**
- * This function is automatically called on version upgrades.
- *
- * Version 1.0.1 introduces a database table for notifications from Adyen.
- *
- * @param Adyen $module
- * @return bool
- */
-function upgrade_module_1_0_1($module)
+class Configuration
 {
-    $module->createAdyenNotificationTable();
-    $module->updateCronJobToken();
-    $module->installTab();
-    return true;
+    const CHECKOUT_COMPONENT_JS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.js';
+    const CHECKOUT_COMPONENT_JS_LIVE = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.0.0/adyen.js';
+    const CHECKOUT_COMPONENT_CSS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css';
+    const CHECKOUT_COMPONENT_CSS_LIVE = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css';
+    const VERSION = '1.0.1';
+    const MODULE_NAME = 'adyen-prestashop';
 }

--- a/helper/Data.php
+++ b/helper/Data.php
@@ -142,7 +142,7 @@ class Data
         $client = $this->createAdyenClient();
         $client->setApplicationName("Prestashop plugin");
         $client->setXApiKey($apiKey);
-        $client->setAdyenPaymentSource(\Adyen\PrestaShop\helper\Configuration::MODULE_NAME, \Adyen\PrestaShop\helper\Configuration::VERSION);
+        $client->setAdyenPaymentSource(\Adyen\PrestaShop\service\Configuration::MODULE_NAME, \Adyen\PrestaShop\service\Configuration::VERSION);
         $client->setExternalPlatform("Prestashop", _PS_VERSION_);
 
         if ($this->isDemoMode()) {

--- a/helper/Data.php
+++ b/helper/Data.php
@@ -142,7 +142,7 @@ class Data
         $client = $this->createAdyenClient();
         $client->setApplicationName("Prestashop plugin");
         $client->setXApiKey($apiKey);
-        $client->setAdyenPaymentSource(Adyen::MODULE_NAME, Adyen::VERSION);
+        $client->setAdyenPaymentSource(\Adyen\PrestaShop\helper\Configuration::MODULE_NAME, \Adyen\PrestaShop\helper\Configuration::VERSION);
         $client->setExternalPlatform("Prestashop", _PS_VERSION_);
 
         if ($this->isDemoMode()) {

--- a/service/ClientFactory.php
+++ b/service/ClientFactory.php
@@ -37,7 +37,7 @@ class ClientFactory
     {
         $client = new \Adyen\Client();
         $client->setXApiKey($encryptedApiKey);
-        $client->setAdyenPaymentSource(\Adyen::MODULE_NAME, \Adyen::VERSION);
+        $client->setAdyenPaymentSource(\Adyen\PrestaShop\helper\Configuration::MODULE_NAME, \Adyen\PrestaShop\helper\Configuration::VERSION);
         $client->setExternalPlatform("PrestaShop", _PS_VERSION_);
         $client->setEnvironment($environment, $liveEndpointUrlPrefix);
         return $client;

--- a/service/ClientFactory.php
+++ b/service/ClientFactory.php
@@ -37,7 +37,7 @@ class ClientFactory
     {
         $client = new \Adyen\Client();
         $client->setXApiKey($encryptedApiKey);
-        $client->setAdyenPaymentSource(\Adyen\PrestaShop\helper\Configuration::MODULE_NAME, \Adyen\PrestaShop\helper\Configuration::VERSION);
+        $client->setAdyenPaymentSource(\Adyen\PrestaShop\service\Configuration::MODULE_NAME, \Adyen\PrestaShop\service\Configuration::VERSION);
         $client->setExternalPlatform("PrestaShop", _PS_VERSION_);
         $client->setEnvironment($environment, $liveEndpointUrlPrefix);
         return $client;

--- a/service/Configuration.php
+++ b/service/Configuration.php
@@ -20,7 +20,7 @@
  * See the LICENSE file for more info.
  */
 
-namespace Adyen\PrestaShop\helper;
+namespace Adyen\PrestaShop\service;
 
 class Configuration
 {

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop plugin
+ *
+ * Copyright (c) 2019 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+namespace Adyen\PrestaShop\service\notification;
+
+use Adyen\PrestaShop\helper\Data as AdyenHelper;
+use Db;
+
+class NotificationProcessor
+{
+    /**
+     * @var AdyenHelper
+     */
+    private $helperData;
+
+    /**
+     * @var Db
+     */
+    private $dbInstance;
+
+    /**
+     * CronProcessor constructor.
+     *
+     * @param AdyenHelper $helperData
+     * @param Db $dbInstance
+     */
+    public function __construct(
+        AdyenHelper $helperData,
+        Db $dbInstance
+    ) {
+        $this->helperData = $helperData;
+        $this->dbInstance = $dbInstance;
+    }
+
+    public function doPostProcess()
+    {
+        $unprocessedNotification = $this->getNextUnprocessedNotification();
+
+        while (!empty($unprocessedNotification)) {
+            // update as processing
+            $this->updateNotificationAsProcessing($unprocessedNotification['entity_id']);
+
+            // Add cron message to order
+            $this->addMessage($unprocessedNotification);
+
+            // processing is done
+            $this->updateNotificationAsDone($unprocessedNotification['entity_id']);
+
+            // get next unprocess notification
+            $unprocessedNotification = $this->getNextUnprocessedNotification();
+        }
+    }
+
+    /**
+     * @return array|bool|null|object
+     */
+    protected function getNextUnprocessedNotification()
+    {
+        $sql = 'SELECT * FROM ' . _DB_PREFIX_ . 'adyen_notification '
+            . 'WHERE `done` = "' . 0 . '"'
+            . ' AND `processing` = "' . 0 . '"';
+        return $this->dbInstance->getRow($sql);
+    }
+
+    /**
+     * Update the unprocessed and not done notification to processing
+     * @param $id
+     * @return mixed
+     */
+    protected function updateNotificationAsProcessing($id)
+    {
+        $sql = 'UPDATE ' . _DB_PREFIX_ . 'adyen_notification '
+            . 'SET `processing` = "' . 1 . '"'
+            . 'WHERE `done` = "' . 0 . '"'
+            . ' AND `processing` = "' . 0 . '"'
+            . ' AND `entity_id` = "' . (int)$id . '"';
+        return $this->dbInstance->execute($sql);
+    }
+
+    /**
+     * Update the processed but not done notification to done
+     * @param $id
+     * @return mixed
+     */
+    protected function updateNotificationAsDone($id)
+    {
+        $sql = 'UPDATE ' . _DB_PREFIX_ . 'adyen_notification '
+            . 'SET `processing` = "' . 0 . '", `done` = "' . 1 . '"'
+            . 'WHERE `done` = "' . 0 . '"'
+            . ' AND `processing` = "' . 1 . '"'
+            . ' AND `entity_id` = "' . (int)$id . '"';
+        return $this->dbInstance->execute($sql);
+    }
+
+    /**
+     * Add order message based on the notification
+     *
+     * @param $notification
+     * @return bool
+     */
+    protected function addMessage($notification)
+    {
+        $successResult = (strcmp($notification['success'], 'true') == 0 ||
+            strcmp($notification['success'], '1') == 0) ? 'true' : 'false';
+        $success = (!empty($notification['reason'])) ? "$successResult <br />reason:" . $notification['reason'] . PHP_EOL : $successResult . PHP_EOL;
+
+        $type = 'Adyen HTTP Notification(s):';
+        $comment = sprintf(
+            '%s <br /> eventCode: %s <br /> pspReference: %s <br /> paymentMethod: %s <br />' .
+            ' success: %s',
+            $type,
+            $notification['event_code'],
+            $notification['pspreference'],
+            $notification['payment_method'],
+            $success
+        );
+
+        if ($this->helperData->isPrestashop16()) {
+            $orderId = \Order::getOrderByCartId($notification['merchant_reference']);
+            $order = new \Order($orderId);
+        } else {
+            $order = \Order::getByCartId($notification['merchant_reference']);
+        }
+
+        if (empty($order)) {
+            $this->helperData->adyenLogger()->logError('Order with id: "' . $notification['merchant_reference'] . '" cannot be found while notification with id: "' . $notification['entity_id'] . '" was processed.');
+            return false;
+        }
+
+        // Find customer by order id
+        $customer = $order->getCustomer();
+        if (empty($customer)) {
+            $this->helperData->adyenLogger()->logError('Customer with id: "' . $order->id_customer . '" cannot be found for order with id: "' . $order->id . '" while notification with id: "' . $notification['entity_id'] . '" was processed.');
+            return false;
+        }
+
+        // Find customer thread by order id and customer email
+        $customerThread = new \CustomerThread(\CustomerThread::getIdCustomerThreadByEmailAndIdOrder($customer->email, $order->id));
+        if (empty($customerThread->id)) {
+            $customer_thread = new \CustomerThread();
+            $customer_thread->id_contact = 0;
+            $customer_thread->id_customer = (int) $customer->id;
+            $customer_thread->id_shop = (int) $this->context->shop->id;
+            $customer_thread->id_order = (int) $order->id;
+            $customer_thread->id_lang = (int) $this->context->language->id;
+            $customer_thread->email = $customer->email;
+            $customer_thread->status = 'open';
+            $customer_thread->token = \Tools::passwdGen(12);
+            $customer_thread->add();
+        }
+
+        // Create message
+        $customerMessage = new \CustomerMessage();
+        $customerMessage->id_customer_thread = $customerThread->id;
+        $customerMessage->id_employee = 1;
+        $customerMessage->message = $comment;
+        $customerMessage->private = 1;
+
+        if (!$customerMessage->add()) {
+            $this->helperData->adyenLogger()->logError('An error occurred while saving the message.');
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/service/notification/NotificationReceiver.php
+++ b/service/notification/NotificationReceiver.php
@@ -237,6 +237,12 @@ class NotificationReceiver
                 'The content of the notification item is: ' . print_r($response, 1)
             );
 
+            // skip report notifications
+            if ($this->isReportNotification($response['eventCode'])) {
+                $this->helperData->adyenLogger()->logDebug('Notification is a REPORT notification from Adyen Customer Area');
+                return true;
+            }
+
             // check if notification already exists
             if (!$this->isTestNotification($response['pspReference']) && !$this->isDuplicate($response)) {
                 $this->insertNotification($response);
@@ -262,9 +268,24 @@ class NotificationReceiver
             || strpos(strtolower($pspReference), 'testnotification_') !== false
         ) {
             return true;
-        } else {
-            return false;
         }
+
+        return false;
+    }
+
+    /**
+     * Check if notification is a report notification
+     *
+     * @param $eventCode
+     * @return bool
+     */
+    protected function isReportNotification($eventCode)
+    {
+        if (strpos($eventCode, 'REPORT_') !== false) {
+            return true;
+        }
+
+        return false;
     }
 
     private function returnAccepted($acceptedMessage)

--- a/service/notification/NotificationReceiver.php
+++ b/service/notification/NotificationReceiver.php
@@ -21,17 +21,13 @@
  * See the LICENSE file for more info.
  */
 
-namespace Adyen\PrestaShop\service;
+namespace Adyen\PrestaShop\service\notification;
 
 use Adyen\PrestaShop\helper\Data as AdyenHelper;
-use Adyen\PrestaShop\service\notification\AuthenticationException;
-use Adyen\PrestaShop\service\notification\AuthorizationException;
-use Adyen\PrestaShop\service\notification\HMACKeyValidationException;
-use Adyen\PrestaShop\service\notification\MerchantAccountCodeException;
 use Adyen\Util\HmacSignature;
 use Db;
 
-class NotificationProcessor
+class NotificationReceiver
 {
     /**
      * @var AdyenHelper
@@ -69,7 +65,7 @@ class NotificationProcessor
     private $dbInstance;
 
     /**
-     * NotificationProcessor constructor.
+     * NotificationReceiver constructor.
      * @param AdyenHelper $helperData
      * @param HmacSignature $hmacSignature
      * @param $notificationHMAC

--- a/tests/service/Adyen/Service/CronControllerTest.php
+++ b/tests/service/Adyen/Service/CronControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop plugin
+ *
+ * Copyright (c) 2019 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+namespace Adyen\PrestaShop\service;
+
+use Adyen\PrestaShop\helper\Data as AdyenHelper;
+use Adyen\PrestaShop\service\notification\AuthenticationException;
+use Adyen\PrestaShop\service\notification\AuthorizationException;
+use Adyen\PrestaShop\service\notification\HMACKeyValidationException;
+use Adyen\PrestaShop\service\notification\MerchantAccountCodeException;
+use Db;
+use Mockery as m;
+
+function pSQL($string)
+{
+    /** @noinspection PhpUndefinedMethodInspection */
+    return CronControllerTest::$functions->pSQL($string);
+}
+
+class CronControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var m\MockInterface
+     */
+    public static $functions;
+
+    /**
+     * @var \FileLogger|\PHPUnit_Framework_MockObject_MockObject $logger
+     */
+    private $logger;
+
+    /**
+     * @var AdyenHelper|\PHPUnit_Framework_MockObject_MockObject $adyenHelper
+     */
+    private $adyenHelper;
+
+    /**
+     * @var Db|\PHPUnit_Framework_MockObject_MockObject $dbInstance
+     */
+    private $dbInstance;
+
+    /**
+     *
+     */
+    protected function setUp()
+    {
+        self::$functions = m::mock();
+
+        $this->logger = $this->getMockBuilder(\FileLogger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->logger->method('logError');
+
+        $this->adyenHelper = $this->getMockBuilder(AdyenHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->adyenHelper->method('adyenLogger')->willReturn($this->logger);
+
+        $this->dbInstance = $this->getMockBuilder(Db::class)->disableOriginalConstructor()->getMock();
+    }
+
+    public function tearDown()
+    {
+        // see Mockery's documentation for why we do this
+        m::close();
+    }
+
+    public function testNotificationIsProcessedAndMessageAdded()
+    {
+        $notification = json_decode(file_get_contents(__DIR__ . '/unprocessed-notification.json'), true);
+
+        $this->dbInstance->method('insert')->with(
+            _DB_PREFIX_ . 'adyen_notification',
+            $this->callback(function ($subject) use ($notification) {
+                $arr = [
+                    'pspreference' => $notification['pspReference'],
+                    'merchant_reference' => $notification['merchantReference'],
+                    'event_code' => $notification['eventCode'],
+                    'success' => $notification['success'],
+                    'payment_method' => $notification['paymentMethod'],
+                    'amount_value' => $notification['amount']['value'],
+                    'amount_currency' => $notification['amount']['currency'],
+                    'reason' => $notification['reason'],
+                    'additional_data' => pSQL(serialize($notification['additionalData'])),
+                    'done' => $notification['done'],
+                    'processing' => $notification['processing'],
+                    'created_at' => $notification['created_at'],
+                    'updated_at' => $notification['updated_at']
+                ];
+                return $arr == $subject;
+            }),
+            false,
+            false,
+            Db::INSERT,
+            false
+        );
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        //$this->assertEquals(true, $notificationReceiver->doPostProcess($notificationItems));
+
+        //todo finish test
+    }
+}

--- a/tests/service/Adyen/Service/NotificationReceiverTest.php
+++ b/tests/service/Adyen/Service/NotificationReceiverTest.php
@@ -34,10 +34,10 @@ use Mockery as m;
 function pSQL($string)
 {
     /** @noinspection PhpUndefinedMethodInspection */
-    return NotificationProcessorTest::$functions->pSQL($string);
+    return NotificationReceiverTest::$functions->pSQL($string);
 }
 
-class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
+class NotificationReceiverTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var m\MockInterface
@@ -97,7 +97,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
         $_SERVER['PHP_AUTH_USER'] = 'username';
         $_SERVER['PHP_AUTH_PW'] = 'password';
 
-        $notificationProcessor = new NotificationProcessor(
+        $notificationReceiver = new NotificationReceiver(
             $this->adyenHelper,
             $this->hmacSignature,
             'hmac',
@@ -110,7 +110,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(HMACKeyValidationException::class);
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $notificationProcessor->doPostProcess(
+        $notificationReceiver->doPostProcess(
             json_decode(file_get_contents(__DIR__ . '/regular-notification.json'), true)
         );
     }
@@ -119,7 +119,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
     {
         $this->adyenHelper->method('isDemoMode')->willReturn(true);
 
-        $notificationProcessor = new NotificationProcessor(
+        $notificationReceiver = new NotificationReceiver(
             $this->adyenHelper,
             $this->hmacSignature,
             'hmac',
@@ -132,7 +132,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(AuthenticationException::class);
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $notificationProcessor->doPostProcess(
+        $notificationReceiver->doPostProcess(
             json_decode(file_get_contents(__DIR__ . '/test-notification.json'), true)
         );
     }
@@ -141,7 +141,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
     {
         $this->adyenHelper->method('isDemoMode')->willReturn(true);
 
-        $notificationProcessor = new NotificationProcessor(
+        $notificationReceiver = new NotificationReceiver(
             $this->adyenHelper,
             $this->hmacSignature,
             'hmac',
@@ -157,7 +157,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(MerchantAccountCodeException::class);
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $notificationProcessor->doPostProcess(
+        $notificationReceiver->doPostProcess(
             json_decode(file_get_contents(__DIR__ . '/invalid-merchant-test-notification.json'), true)
         );
     }
@@ -166,7 +166,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
     {
         $this->adyenHelper->method('isDemoMode')->willReturn(true);
 
-        $notificationProcessor = new NotificationProcessor(
+        $notificationReceiver = new NotificationReceiver(
             $this->adyenHelper,
             $this->hmacSignature,
             'hmac',
@@ -182,7 +182,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(AuthorizationException::class);
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $notificationProcessor->doPostProcess(
+        $notificationReceiver->doPostProcess(
             json_decode(file_get_contents(__DIR__ . '/invalid-merchant-notification.json'), true)
         );
     }
@@ -229,7 +229,7 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
         $_SERVER['PHP_AUTH_USER'] = 'username';
         $_SERVER['PHP_AUTH_PW'] = 'password';
 
-        $notificationProcessor = new NotificationProcessor(
+        $notificationReceiver = new NotificationReceiver(
             $this->adyenHelper,
             $this->hmacSignature,
             'hmac',
@@ -240,6 +240,6 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
         );
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $this->assertEquals('[accepted]', $notificationProcessor->doPostProcess($notificationItems));
+        $this->assertEquals('[accepted]', $notificationReceiver->doPostProcess($notificationItems));
     }
 }

--- a/tests/service/Adyen/Service/unprocessed-notification.json
+++ b/tests/service/Adyen/Service/unprocessed-notification.json
@@ -1,0 +1,18 @@
+{
+  "entity_id": 1,
+  "pspreference": "883569413203437H",
+  "original_reference": null,
+  "merchant_reference": "76",
+  "event_code": "AUTHORISATION",
+  "success": "true",
+  "payment_method": "visa",
+  "amount_value": "2600",
+  "amount_currency": "EUR",
+  "reason": "40446:1111:10/2020",
+  "live": null,
+  "additional_data": "a:37:{s:32:\"fraudCheck-25-CVCAuthResultCheck\";s:1:\"0\";s:9:\"avsResult\";s:38:\"4 AVS not supported for this card type\";s:43:\"fraudCheck-41-PaymentDetailNonFraudRefCheck\";s:2:\"50\";s:11:\"cardSummary\";s:4:\"1111\";s:16:\"refusalReasonRaw\";s:10:\"AUTHORISED\";s:15:\"totalFraudScore\";s:2:\"51\";s:13:\"hmacSignature\";s:44:\"m2aacYH3DiS/4T5cvR8UR6O+lNVUvhGnJC7WHjuA9Kc=\";s:10:\"expiryDate\";s:7:\"10/2020\";s:36:\"fraudCheck-15-IssuingCountryReferral\";s:1:\"0\";s:7:\"cardBin\";s:6:\"411111\";s:19:\"threeDAuthenticated\";s:5:\"false\";s:5:\"alias\";s:16:\"H167852639363479\";s:12:\"cvcResultRaw\";s:1:\"M\";s:28:\"fraudCheck-4-HolderNameUsage\";s:1:\"0\";s:17:\"merchantReference\";s:2:\"76\";s:17:\"acquirerReference\";s:11:\"7CB2HLCPRLU\";s:27:\"fraudCheck-2-CardChunkUsage\";s:1:\"0\";s:28:\"fraudCheck-13-IssuerRefCheck\";s:1:\"0\";s:38:\"fraudCheck-10-HolderNameContainsNumber\";s:1:\"0\";s:18:\"cardIssuingCountry\";s:2:\"NL\";s:11:\"fraudOffset\";s:1:\"0\";s:14:\"liabilityShift\";s:5:\"false\";s:15:\"fraudResultType\";s:5:\"AMBER\";s:8:\"authCode\";s:5:\"40446\";s:14:\"cardHolderName\";s:6:\"attila\";s:17:\"fraudManualReview\";s:4:\"true\";s:13:\"threeDOffered\";s:4:\"true\";s:31:\"fraudCheck-3-PaymentDetailUsage\";s:1:\"0\";s:15:\"cardIssuingBank\";s:15:\"ADYEN TEST BANK\";s:29:\"fraudCheck-27-PmOwnerRefCheck\";s:1:\"0\";s:33:\"fraudCheck-11-HolderNameIsOneWord\";s:1:\"1\";s:9:\"cvcResult\";s:9:\"1 Matches\";s:34:\"fraudCheck-1-PaymentDetailRefCheck\";s:1:\"0\";s:9:\"aliasType\";s:7:\"Default\";s:12:\"avsResultRaw\";s:1:\"4\";s:17:\"cardPaymentMethod\";s:4:\"visa\";s:12:\"acquirerCode\";s:15:\"TestPmmAcquirer\";}",
+  "done": 0,
+  "processing": 0,
+  "created_at": "2019-09-25 14:06:44",
+  "updated_at": "2019-09-25 12:31:10"
+}


### PR DESCRIPTION
 - Add new admin controller which the cronjob can use to process
notifications
 - Rename notificationProcessor to notificationReceiver because it
 handles receiving and saving notifications
 - Fix for ajaxRender: exit after rendering
 - Fix for ajaxRender: set this->ajax to true by default
 - Fix for try catches: if catch triggered, return something ot exit to
 prevent errors
 - Create Configuration class for global settings
 - Fix for link generation: burnt in links are not working since
 friendly url setting overwrites the default url structure and triggers
 error when trying to open an 'old' link
 - add installTab and createCronJobToken to upgrade 1.0.1
 - process authorisation notifications - adding a message if processed
 - expose admin controller for cron jobs to call