### PR TITLE
Fix for fresh install when ADYEN_MODE is empty

### DIFF
--- a/adyen.php
+++ b/adyen.php
@@ -77,9 +77,14 @@ class Adyen extends PaymentModule
         $this->ps_versions_compliancy = array('min' => '1.6', 'max' => _PS_VERSION_);
         $this->currencies = true;
 
+        $adyenRunningMode = 'test';
+        if (!empty(\Configuration::get('ADYEN_MODE'))) {
+            $adyenRunningMode = \Configuration::get('ADYEN_MODE');
+        }
+
         $adyenHelperFactory = new Adyen\PrestaShop\service\helper\DataFactory();
         $this->helper_data = $adyenHelperFactory->createAdyenHelperData(
-            Configuration::get('ADYEN_MODE'),
+            $adyenRunningMode,
             _COOKIE_KEY_
         );
 

--- a/helper/Data.php
+++ b/helper/Data.php
@@ -24,8 +24,6 @@ namespace Adyen\PrestaShop\helper;
 
 use Adyen;
 use Adyen\AdyenException;
-use Adyen\Service\CheckoutUtility;
-use Adyen\Service\Checkout;
 use \Currency;
 use \Address;
 use \Country;
@@ -61,8 +59,8 @@ class Data
         $httpHost,
         $configuration,
         $sslEncryptionKey,
-        CheckoutUtility $adyenCheckoutUtilityService,
-        Checkout $adyenCheckoutService
+        $adyenCheckoutUtilityService,
+        $adyenCheckoutService
     ) {
         $this->httpHost = $httpHost;
         $this->configuration = $configuration;

--- a/helper/Data.php
+++ b/helper/Data.php
@@ -24,6 +24,8 @@ namespace Adyen\PrestaShop\helper;
 
 use Adyen;
 use Adyen\AdyenException;
+use Adyen\Service\CheckoutUtility;
+use Adyen\Service\Checkout;
 use \Currency;
 use \Address;
 use \Country;
@@ -59,8 +61,8 @@ class Data
         $httpHost,
         $configuration,
         $sslEncryptionKey,
-        $adyenCheckoutUtilityService,
-        $adyenCheckoutService
+        CheckoutUtility $adyenCheckoutUtilityService,
+        Checkout $adyenCheckoutService
     ) {
         $this->httpHost = $httpHost;
         $this->configuration = $configuration;


### PR DESCRIPTION
Since this value is not set before installing the plugin the plugin doesn't show up in the modules list, therefore we provide a default value for the ADYEN_MODE configuration.