### PR TITLE
PW-1891 Treat a `Refused` error code for 3DS process

### DIFF
--- a/controllers/front/ThreeDSProcess.php
+++ b/controllers/front/ThreeDSProcess.php
@@ -118,6 +118,15 @@ class AdyenThreeDSProcessModuleFrontController extends \Adyen\PrestaShop\control
             ));
         }
 
+        if ($result['resultCode'] == 'Refused') {
+            $this->ajaxRender(
+                $this->helperData->buildControllerResponseJson(
+                    'error',
+                    array('message' => 'The payment was refused')
+                )
+            );
+        }
+
         // Payment can get back to the original flow
         // Save the payments response because we are going to need it during the place order flow
         $_SESSION["paymentsResponse"] = $result;

--- a/controllers/front/ThreeDSProcess.php
+++ b/controllers/front/ThreeDSProcess.php
@@ -118,7 +118,7 @@ class AdyenThreeDSProcessModuleFrontController extends \Adyen\PrestaShop\control
             ));
         }
 
-        if ($result['resultCode'] == 'Refused') {
+        if (!empty($result['resultCode']) && $result['resultCode'] == 'Refused') {
             $this->ajaxRender(
                 $this->helperData->buildControllerResponseJson(
                     'error',


### PR DESCRIPTION
As of now, our PrestaShop plugin would show a blank page with a JSON with the error message. This is because the back-end would send an empty response with a 200 status code, tricking the front-end into treating this as a successful payment.

Changing the action of this response to `error` will inform the front-end how to properly handle this issue.