### PR TITLE
Use simpler CSS for errors

### DIFF
--- a/css/adyen.css
+++ b/css/adyen.css
@@ -1,3 +1,24 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop plugin
+ *
+ * Copyright (c) 2019 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
 .adyen-logo-link { margin-top: 10px;}
 .adyen-logo { margin-top: -13px;} 
 
@@ -14,13 +35,6 @@ ul.adyen-hpp-options { list-style-type:none; margin-left:10px;}
 				ul.adyen-hpp-options li ul.payment_form_ideal input { margin-top:25px;}
 
 div.adyen-payment #errors {
-	margin: 0 0 10px 0;
-	padding: 10px;
-	border: 1px solid #900;
-	color: #900;
-	font-size: 13px;
-	background: #FCC;
-	width: 210px;
 	display: none;
 }
 

--- a/views/templates/front/payment.tpl
+++ b/views/templates/front/payment.tpl
@@ -19,7 +19,7 @@
             >
 
                 <!-- Display payment errors -->
-                <div id="errors" role="alert"></div>
+                <div id="errors" class="alert alert-danger" role="alert"></div>
 
                 <div class="checkout-container" id="cardContainer"></div>
                 <input type="hidden" name="paymentData"/>


### PR DESCRIPTION
Since PrestaShop uses Bootstrap on the default theme, removing CSS properties from our custom CSS will make customization easier.