### PR TITLE
Remove `prepend-autoloader` option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,9 @@
       "Adyen\\PrestaShop\\": ""
     }
   },
+  "config": {
+    "prepend-autoloader": false
+  },
   "require": {
     "adyen/php-api-library": "~5",
     "ext-json": "*",


### PR DESCRIPTION
According to the [PrestaShop documentation and the code validator](https://devdocs.prestashop.com/1.7/modules/concepts/composer/#important-notes), the `prepend-autoloader` property needs to be set to `false` in the `composer.json` file, otherwise it might break the PrestaShop instance.