### PR TITLE
[PW-2235]: Adding translations to smarty templates

### DIFF
--- a/views/templates/front/adyencheckout.tpl
+++ b/views/templates/front/adyencheckout.tpl
@@ -22,8 +22,7 @@
  *}
 
 {if !$originKey}
-    <h5>There is an error with retrieving the originKey,
-        please check your API key in the Adyen Module configuration</h5>
+    {include './originkey-error.tpl'}
 {else}
     <div id="adyen-checkout-configuration"
          data-is-presta-shop16="{$isPrestaShop16|escape:'html'}"

--- a/views/templates/front/card-payment-method.tpl
+++ b/views/templates/front/card-payment-method.tpl
@@ -23,8 +23,7 @@
 
 {if !$originKey}
     <form method="post">
-        <h5>There is an error with retrieving the originKey,
-            please check your API key in the Adyen Module configuration</h5>
+        {include './originkey-error.tpl'}
     </form>
 {else}
     {if $prestashop16}
@@ -61,7 +60,7 @@
                         <div class="modal-dialog" role="document">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h4 class="modal-title">Authentication</h4>
+                                    <h4 class="modal-title">{l s='Authentication' mod='adyenofficial'}</h4>
                                 </div>
                                 <div class="modal-body">
                                     <div id="threeDS2Container"></div>

--- a/views/templates/front/local-payment-method.tpl
+++ b/views/templates/front/local-payment-method.tpl
@@ -23,8 +23,7 @@
 
 {if !$originKey}
     <form method="post">
-        <h5>There is an error with retrieving the originKey,
-            please check your API key in the Adyen Module configuration</h5>
+        {include './originkey-error.tpl'}
     </form>
 {else}
     <div class="row adyen-payment {$paymentMethodType|escape:'html'}"

--- a/views/templates/front/order-confirmation.tpl
+++ b/views/templates/front/order-confirmation.tpl
@@ -26,7 +26,7 @@
 {if !empty($action) or !empty($additionalData)}
     <div class="row">
       <div class="col-md-12">
-        <h3 class="card-title h3">Please use these details to finish the payment:</h3>
+        <h3 class="card-title h3">{l s='Please use these details to finish the payment' mod='adyenofficial'}:</h3>
         {if !empty($action)}
           <div
                   data-adyen-payment-action-container

--- a/views/templates/front/originkey-error.tpl
+++ b/views/templates/front/originkey-error.tpl
@@ -21,5 +21,4 @@
  * See the LICENSE file for more info.
  *}
 
-<h5>{l s='There is an error with retrieving the originKey' mod='adyenofficial'},
-    {l s='please check your API key in the Adyen Module configuration' mod='adyenofficial'}</h5>
+<h5>{l s='There is an error with retrieving the originKey, please check your API key in the Adyen Module configuration.' mod='adyenofficial'}</h5>

--- a/views/templates/front/originkey-error.tpl
+++ b/views/templates/front/originkey-error.tpl
@@ -21,19 +21,5 @@
  * See the LICENSE file for more info.
  *}
 
-<div style="display: flex;">
-    <div style="float:left;padding-right:10px;">
-        <img width="120px" src="{$logo}">
-    </div>
-    <div>
-        <p>{l s='Adyen all-in-one payments platform.' mod='adyenofficial'}</p>
-        <p>{l s='Offer key payment methods anywhere in the world at the flick of a switch.' mod='adyenofficial'}</p>
-        <p>{l s='Easy integration with our in-house built PrestaShop Plugin, no set-up fee.' mod='adyenofficial'}</p>
-        <p>{l s='Sign up for an Adyen account at' mod='adyenofficial'} <a href="https://www.adyen.com/signup">https://www.adyen.com/signup</a></p>
-    </div>
-</div>
-<div>
-    {foreach from=$links item=value name=links}
-        <a href="{$value.url}" target="_blank">{$value.label}</a> {if not $smarty.foreach.links.last} | {/if}
-    {/foreach}
-</div>
+<h5>{l s='There is an error with retrieving the originKey' mod='adyenofficial'},
+    {l s='please check your API key in the Adyen Module configuration' mod='adyenofficial'}</h5>

--- a/views/templates/front/redirect.tpl
+++ b/views/templates/front/redirect.tpl
@@ -38,8 +38,8 @@
         <br>
         <br>
         <div style="text-align: center">
-            <h1>Processing your 3-D Secure Transaction</h1>
-            <p>Please click continue to continue the processing of your 3-D Secure transaction.</p>
+            <h1>{l s='Processing your 3-D Secure Transaction' mod='adyenofficial'}</h1>
+            <p>{l s='Please click continue to continue the processing of your 3-D Secure transaction.' mod='adyenofficial'}</p>
             <input type="submit" class="button" value="continue"/>
         </div>
     </noscript>

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -23,8 +23,7 @@
 
 {if !$originKey}
     <form method="post">
-        <h5>There is an error with retrieving the originKey,
-            please check your API key in the Adyen Module configuration</h5>
+        {include './originkey-error.tpl'}
     </form>
 {else}
     <div class="row adyen-payment"
@@ -63,7 +62,7 @@
                         <div class="modal-dialog" role="document">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h4 class="modal-title">Authentication</h4>
+                                    <h4 class="modal-title">{l s='Authentication' mod='adyenofficial'}</h4>
                                 </div>
                                 <div class="modal-body">
                                     <div id="threeDS2Container-{$storedPaymentApiId|escape:'html'}"></div>


### PR DESCRIPTION
Wrapping the smarty strings in the translation function.

A new originkey-error template was created to include the same message in multiple templates.

Prestashop generates translations files when the localization form is filled. So unless the plugin needs to ship in multiple languages out of the box we do not need to add translation files.

Tested scenarios:
Triggered OriginKey error for payment methods.
Translated config titles in admin panel.
PS 1.7 and 1.6.