### PR TITLE
[PW-2241] Update processing Authorisation and Offer_Closed notifications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~4",
-    "mockery/mockery": "dev-master",
+    "mockery/mockery": "1.3.*",
     "squizlabs/php_codesniffer": "3.*",
     "prestashop/autoindex": "~1"
   }

--- a/model/AdyenNotification.php
+++ b/model/AdyenNotification.php
@@ -213,4 +213,17 @@ class AdyenNotification extends AbstractModel
 
         return $this->dbInstance->getValue($sql);
     }
+
+    /**
+     * @param $merchantReference
+     * @return mixed
+     */
+    public function getProcessedNotificationsByMerchantReference($merchantReference)
+    {
+        $sql = 'SELECT * FROM ' . _DB_PREFIX_ . self::$tableName
+            . ' WHERE `merchant_reference` = "' . pSQL($merchantReference) . '"'
+            . ' AND `done` = 1';
+
+        return $this->dbInstance->executeS($sql);
+    }
 }

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -145,7 +145,10 @@ class NotificationProcessor
                             // AUTHORISATION success = false moves order to canceled if not canceled already
                             $order->setCurrentState(\Configuration::get('PS_OS_CANCELED'));
                         } else {
-                            $this->logger->addAdyenNotification('Notification with entity_id (' . $unprocessedNotification['entity_id'] . ') was ignored during processing the notifications because another Authorisation success = true notification has already been processed for the same order.');
+                            $this->logger->addAdyenNotification('Notification with entity_id (' .
+                                $unprocessedNotification['entity_id'] . ') was ignored during processing the ' .
+                                'notifications because another Authorisation success = true notification has already ' .
+                                'been processed for the same order.');
                         }
                     }
                 }
@@ -281,8 +284,7 @@ class NotificationProcessor
         $hasProcessedAuthorisedNotification = false;
 
         foreach ($processedNotifications as $processedNotification) {
-            if (
-                AdyenNotification::AUTHORISATION === $processedNotification['event_code'] &&
+            if (AdyenNotification::AUTHORISATION === $processedNotification['event_code'] &&
                 'true' === $processedNotification['success']
             ) {
                 $hasProcessedAuthorisedNotification = true;

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -281,16 +281,14 @@ class NotificationProcessor
             return false;
         }
 
-        $hasProcessedAuthorisedNotification = false;
-
         foreach ($processedNotifications as $processedNotification) {
             if (AdyenNotification::AUTHORISATION === $processedNotification['event_code'] &&
                 'true' === $processedNotification['success']
             ) {
-                $hasProcessedAuthorisedNotification = true;
+                return true;
             }
         }
 
-        return $hasProcessedAuthorisedNotification;
+        return false;
     }
 }

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -140,7 +140,6 @@ class NotificationProcessor
                     // Add additional data to order if there is any (only possible when the notification success is true
                     $this->orderService->addPaymentDataToOrderFromResponse($order, $unprocessedNotification);
                 } else { // Notification success is 'false'
-
                     // Order state is not canceled yet
                     if ($order->getCurrentState() !== \Configuration::get('PS_OS_CANCELED')) {
                         // No previous authorisation notification was processed before


### PR DESCRIPTION
 - Take success field into consideration when processing the
 notifications
 - Add getProcessedNotificationsByMerchantReference() to retrieve a list
 of already processed notifications for an order by merchant_reference
 - Add hasProcessedAuthorisationSuccessNotification() to check if an
 order has already had an Authorised notification with success = true
 value processed