### PR TITLE
[PW-2694] Hide BCMC until we implement generic component

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1410,6 +1410,7 @@ class AdyenOfficial extends PaymentModule
      */
     private function isUnsupportedPaymentMethod($paymentMethodType)
     {
+        // TODO Revise the list when implementing PW-2215
         $unsupportedPaymentMethods = array(
             'bcmc',
             'scheme',

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1411,6 +1411,7 @@ class AdyenOfficial extends PaymentModule
     private function isUnsupportedPaymentMethod($paymentMethodType)
     {
         $unsupportedPaymentMethods = array(
+            'bcmc',
             'scheme',
             'bcmc_mobile_QR',
             'wechatpay',


### PR DESCRIPTION
## Summary
BCMC works now only within the card component so hide the separate BCMC component for now until we implement the generic component and approach in ticket PW-2215 