### PR TITLE
Fix escaping for the PrestaShop validator

### DIFF
--- a/views/templates/front/adyencheckout.tpl
+++ b/views/templates/front/adyencheckout.tpl
@@ -25,11 +25,11 @@
     {include './originkey-error.tpl'}
 {else}
     <div id="adyen-checkout-configuration"
-         data-is-presta-shop16="{$isPrestaShop16|escape:'html'}"
-         data-locale="{$locale|escape:'html'}"
-         data-origin-key="{$originKey|escape:'html'}"
-         data-environment="{$environment|escape:'html'}"
-         data-payment-methods-response='{$paymentMethodsResponse|escape:'html'}'
+         data-is-presta-shop16="{$isPrestaShop16|escape:'html':'UTF-8'}"
+         data-locale="{$locale|escape:'html':'UTF-8'}"
+         data-origin-key="{$originKey|escape:'html':'UTF-8'}"
+         data-environment="{$environment|escape:'html':'UTF-8'}"
+         data-payment-methods-response='{$paymentMethodsResponse|escape:'html':'UTF-8'}'
     ></div>
     <script>
         var adyenCheckoutConfiguration = document.querySelector('#adyen-checkout-configuration').dataset;

--- a/views/templates/front/card-payment-method.tpl
+++ b/views/templates/front/card-payment-method.tpl
@@ -34,9 +34,9 @@
     {/if}
     <div class="row adyen-payment">
         <div class="col-xs-12 col-md-6">
-            <form action="{$paymentProcessUrl|escape:'html'}" class="adyen-payment-form" method="post"
-                  data-is-logged-in-user="{$loggedInUser|escape:'html'}"
-                  data-three-ds-process-url="{$threeDSProcessUrl|escape:'html'}"
+            <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}" class="adyen-payment-form" method="post"
+                  data-is-logged-in-user="{$loggedInUser|escape:'html':'UTF-8'}"
+                  data-three-ds-process-url="{$threeDSProcessUrl|escape:'html':'UTF-8'}"
             >
 
                 <!-- Display payment errors -->

--- a/views/templates/front/get-started.tpl
+++ b/views/templates/front/get-started.tpl
@@ -23,17 +23,19 @@
 
 <div style="display: flex;">
     <div style="float:left;padding-right:10px;">
-        <img width="120px" src="{$logo|escape:'html'}">
+        <img width="120px" src="{$logo|escape:'html':'UTF-8'}">
     </div>
     <div>
         <p>{l s='Adyen all-in-one payments platform.' mod='adyenofficial'}</p>
         <p>{l s='Offer key payment methods anywhere in the world at the flick of a switch.' mod='adyenofficial'}</p>
         <p>{l s='Easy integration with our in-house built PrestaShop Plugin, no set-up fee.' mod='adyenofficial'}</p>
-        <p>{l s='Sign up for an Adyen account at' mod='adyenofficial'} <a href="https://www.adyen.com/signup">https://www.adyen.com/signup</a></p>
+        <p>{l s='Sign up for an Adyen account at' mod='adyenofficial'} <a href="https://www.adyen.com/signup">https://www.adyen.com/signup</a>
+        </p>
     </div>
 </div>
 <div>
     {foreach from=$links item=value name=links}
-        <a href="{$value.url|escape:'html'}" target="_blank">{$value.label|escape:'html'}</a> {if not $smarty.foreach.links.last} | {/if}
+        <a href="{$value.url|escape:'html':'UTF-8'}" target="_blank">{$value.label|escape:'html':'UTF-8'}</a>
+        {if not $smarty.foreach.links.last} | {/if}
     {/foreach}
 </div>

--- a/views/templates/front/local-payment-method.tpl
+++ b/views/templates/front/local-payment-method.tpl
@@ -26,11 +26,12 @@
         {include './originkey-error.tpl'}
     </form>
 {else}
-    <div class="row adyen-payment {$paymentMethodType|escape:'html'}"
-         data-local-payment-method="{$paymentMethodType|escape:'html'}"
+    <div class="row adyen-payment {$paymentMethodType|escape:'html':'UTF-8'}"
+         data-local-payment-method="{$paymentMethodType|escape:'html':'UTF-8'}"
     >
-        <div class="adyen-payment-method-label">{l s='Pay with ' mod='adyenofficial'}{$paymentMethodName|escape:'html'}</div>
-        <form action="{$paymentProcessUrl|escape:'html'}" class="adyen-payment-form-{$paymentMethodType|escape:'html'}" method="post">
+        <div class="adyen-payment-method-label">{l s='Pay with ' mod='adyenofficial'}{$paymentMethodName|escape:'html':'UTF-8'}</div>
+        <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
+              class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'}" method="post">
             <!-- Display payment errors -->
             <div class="alert alert-danger error-container" role="alert"></div>
             <div data-adyen-payment-container></div>

--- a/views/templates/front/order-confirmation.tpl
+++ b/views/templates/front/order-confirmation.tpl
@@ -28,18 +28,18 @@
       <div class="col-md-12">
         <h3 class="card-title h3">{l s='Please use these details to finish the payment' mod='adyenofficial'}:</h3>
         {if !empty($action)}
-          <div
-                  data-adyen-payment-action-container
-                  data-adyen-payment-action="{$action|escape:'html'}"
-          ></div>
+            <div
+                    data-adyen-payment-action-container
+                    data-adyen-payment-action="{$action|escape:'html':'UTF-8'}"
+            ></div>
         {/if}
 
-        {if !empty($additionalData)}
-          <div
-                  data-adyen-payment-additional-data-container
-                  data-adyen-payment-additional-data="{$additionalData|escape:'html'}"
-          ></div>
-        {/if}
+          {if !empty($additionalData)}
+              <div
+                      data-adyen-payment-additional-data-container
+                      data-adyen-payment-additional-data="{$additionalData|escape:'html':'UTF-8'}"
+              ></div>
+          {/if}
         <div data-adyen-payment-error-container role="alert"></div>
       </div>
     </div>

--- a/views/templates/front/redirect.tpl
+++ b/views/templates/front/redirect.tpl
@@ -24,16 +24,16 @@
 {if $redirectMethod == "GET"}
     <body>
     <script>
-        window.location.replace("{$issuerUrl|escape:'html'}");
+        window.location.replace("{$issuerUrl|escape:'html':'UTF-8'}");
     </script>
     </body>
 {/if}
 
 <body onload="document.getElementById('3dform').submit();">
-<form method="POST" action="{$issuerUrl|escape:'html'}" id="3dform">
-    <input type="hidden" name="PaReq" value="{$paRequest|escape:'html'}"/>
-    <input type="hidden" name="MD" value="{$md|escape:'html'}"/>
-    <input type="hidden" name="TermUrl" value="{$termUrl|escape:'html'}"/>
+<form method="POST" action="{$issuerUrl|escape:'html':'UTF-8'}" id="3dform">
+    <input type="hidden" name="PaReq" value="{$paRequest|escape:'html':'UTF-8'}"/>
+    <input type="hidden" name="MD" value="{$md|escape:'html':'UTF-8'}"/>
+    <input type="hidden" name="TermUrl" value="{$termUrl|escape:'html':'UTF-8'}"/>
     <noscript>
         <br>
         <br>

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -27,11 +27,12 @@
     </form>
 {else}
     <div class="row adyen-payment"
-         data-three-ds-process-url="{$threeDSProcessUrl|escape:'html'}"
-         data-stored-payment-api-id="{$storedPaymentApiId|escape:'html'}"
+         data-three-ds-process-url="{$threeDSProcessUrl|escape:'html':'UTF-8'}"
+         data-stored-payment-api-id="{$storedPaymentApiId|escape:'html':'UTF-8'}"
     >
         <div class="col-xs-12 col-md-6">
-            <form action="{$paymentProcessUrl|escape:'html'}" class="adyen-payment-form-{$storedPaymentApiId|escape:'html'}" method="post">
+            <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
+                  class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}" method="post">
 
                 <!-- Display payment errors -->
                 <div class="alert alert-danger error-container" role="alert"></div>
@@ -39,12 +40,12 @@
                 {if $prestashop16}
                     <p></p>
                     <div class="adyen-payment-method-label">
-                        {l s='Pay with saved ' mod='adyenofficial'} {$name|escape:'html'}
-                        {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html'}
+                        {l s='Pay with saved ' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
+                        {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
                     </div>
                 {/if}
 
-                <div class="checkout-container" id="cardContainer-{$storedPaymentApiId|escape:'html'}"></div>
+                <div class="checkout-container" id="cardContainer-{$storedPaymentApiId|escape:'html':'UTF-8'}"></div>
                 <input type="hidden" name="redirectMethod"/>
                 <input type="hidden" name="issuerUrl"/>
                 <input type="hidden" name="paRequest"/>
@@ -53,19 +54,20 @@
 
                 {if $prestashop16}
                     <div style="display:none">
-                        <div id="threeDS2Modal-{$storedPaymentApiId|escape:'html'}">
-                            <div id="threeDS2Container-{$storedPaymentApiId|escape:'html'}"></div>
+                        <div id="threeDS2Modal-{$storedPaymentApiId|escape:'html':'UTF-8'}">
+                            <div id="threeDS2Container-{$storedPaymentApiId|escape:'html':'UTF-8'}"></div>
                         </div>
                     </div>
                 {else}
-                    <div id="threeDS2Modal-{$storedPaymentApiId|escape:'html'}" class="modal fade" tabindex="-1" role="dialog">
+                    <div id="threeDS2Modal-{$storedPaymentApiId|escape:'html':'UTF-8'}" class="modal fade" tabindex="-1"
+                         role="dialog">
                         <div class="modal-dialog" role="document">
                             <div class="modal-content">
                                 <div class="modal-header">
                                     <h4 class="modal-title">{l s='Authentication' mod='adyenofficial'}</h4>
                                 </div>
                                 <div class="modal-body">
-                                    <div id="threeDS2Container-{$storedPaymentApiId|escape:'html'}"></div>
+                                    <div id="threeDS2Container-{$storedPaymentApiId|escape:'html':'UTF-8'}"></div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Fix issue with the PrestaShop code validator, enforcing a character set to all variables used in template files.

## Tested scenarios
<!-- Description of tested scenarios -->
Submitted the plugin to the PrestaShop Validator website


**Fixed issue**:  <!-- #-prefixed issue number -->
