### PR TITLE
[PW-2731] Fix refund with shipping costs

### DIFF
--- a/service/modification/Refund.php
+++ b/service/modification/Refund.php
@@ -84,7 +84,15 @@ class Refund
     public function request(OrderSlip $orderSlip, $currency)
     {
         $currencyConverter = new Currency();
-        $amount = $currencyConverter->sanitize($orderSlip->amount, $currency);
+
+        $fullRefundAmount = $orderSlip->amount;
+
+        // In case shipping cost amount is not empty add shipping costs to the order slip amount
+        if (!empty($orderSlip->shipping_cost_amount)) {
+            $fullRefundAmount += $orderSlip->shipping_cost_amount;
+        }
+
+        $amount = $currencyConverter->sanitize($fullRefundAmount, $currency);
 
         try {
             $pspReference = $this->notificationRetriever->getPSPReferenceByOrderId($orderSlip->id_order);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
PrestaShop refunds do not work for shipping costs, only for the costs of a product.

## Tested scenarios
<!-- Description of tested scenarios -->
Refund shipping costs in PrestaShop 1.6 and 1.7
