### PR TITLE
Fix open invoice line item for shipping costs

### DIFF
--- a/controllers/front/Payment.php
+++ b/controllers/front/Payment.php
@@ -1,5 +1,5 @@
 <?php
-/**
+/*
  *                       ######
  *                       ######
  * ############    ####( ######  #####. ######  ############   ############
@@ -645,6 +645,10 @@ class AdyenOfficialPaymentModuleFrontController extends FrontController
         $deliveryCost = $cart->getPackageShippingCost();
         $cartSummary = $cart->getSummaryDetails();
         $carrier = $cartSummary['carrier'];
+        $totalShipping = $this->utilCurrency->sanitize(
+            $cartSummary['total_shipping'],
+            $this->context->currency->iso_code
+        );
         $shippingTax = ($cartSummary['total_shipping'] - $cartSummary['total_shipping_tax_exc']) * 100;
 
         if ($cartSummary['total_shipping']) {
@@ -656,7 +660,7 @@ class AdyenOfficialPaymentModuleFrontController extends FrontController
         if ($deliveryCost) {
             $lineItems[] = $this->openInvoiceBuilder->buildOpenInvoiceLineItem(
                 $carrier->name,
-                $cartSummary['total_shipping'],
+                $totalShipping,
                 $shippingTax,
                 $shippingTaxRate,
                 1,


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The current calculation sends information as a floating point number, which is incorrect and prone to issues when dealing with non-exact costs (€8.05, for example).

To fix this, we are formatting the number we get as shipping costs from PrestaShop and formatting it to cents before sending it to Adyen servers.

## Tested scenarios
<!-- Description of tested scenarios -->
Selected Klarna Pay Now in the checkout process. Before the fix, it was impossible to move on if the cost was not round (tested with shipping costs of €8.05). After the fix, user is redirected.

**Fixed issue**:  PW-2997
