### PR TITLE
Set fixed dimensions for the 3DS2 modal in PrestaShop 1.6

### DIFF
--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -296,7 +296,6 @@ function renderPaymentMethods() {
 
         try {
             actionComponent.createFromAction(action).mount('#actionContainer');
-            //$.fancybox.update()
         } catch (e) {
             console.log(e);
             hidePopup();
@@ -336,11 +335,7 @@ function renderPaymentMethods() {
     function showPopup() {
         if (IS_PRESTA_SHOP_16) {
             $.fancybox({
-                'autoDimensions': false,
-                'autoScale': false,
                 'autoSize': false,
-                'width': 500,
-                'height': 500,
                 'centerOnScroll': true,
                 'href': '#actionModal',
                 'modal': true,

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -288,16 +288,18 @@ function renderPaymentMethods() {
         // TODO remove when fix is rolled out in a new checkout component version
         delete configuration.data;
 
+        if (action.type === 'threeDS2Challenge') {
+            showPopup();
+        }
+
         var actionComponent = window.adyenCheckout = new AdyenCheckout(configuration);
 
         try {
             actionComponent.createFromAction(action).mount('#actionContainer');
-
-            if (action.type === 'threeDS2Challenge') {
-                showPopup();
-            }
+            //$.fancybox.update()
         } catch (e) {
             console.log(e);
+            hidePopup();
         }
     }
 
@@ -336,6 +338,9 @@ function renderPaymentMethods() {
             $.fancybox({
                 'autoDimensions': true,
                 'autoScale': true,
+                'autoSize' : true,
+                'width':500,
+                'height':500,
                 'centerOnScroll': true,
                 'href': '#actionModal',
                 'modal': true,

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -336,11 +336,11 @@ function renderPaymentMethods() {
     function showPopup() {
         if (IS_PRESTA_SHOP_16) {
             $.fancybox({
-                'autoDimensions': true,
-                'autoScale': true,
-                'autoSize' : true,
-                'width':500,
-                'height':500,
+                'autoDimensions': false,
+                'autoScale': false,
+                'autoSize': false,
+                'width': 500,
+                'height': 500,
                 'centerOnScroll': true,
                 'href': '#actionModal',
                 'modal': true,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Adyen Components have protection from cloning nodes in place which interferes with the modal component in PrestaShop 1.6. To make it work with Fancybox we have changed the order of rendering the components and modal, but this introduced an issue where the modal could not be resized.

This pull request will make the modal a fixed size. This is due to a limitation in the technologies present and there's no way of changing this without over-engineering a component that reads the size of the contents of the iframe, which will probably not going to work in every case anyways.

If there's the requirement of making it more flexible we can introduce configuration to allow implementations of the plugin to determine the size of the modal.

## Tested scenarios
<!-- Description of tested scenarios -->
Payment with 3DS2 cards in PrestaShop 1.6 and 1.7.
