### PR TITLE
Prefill the billing address and country code in 1.6 on the frontend

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1080,7 +1080,8 @@ class AdyenOfficial extends PaymentModule
 
         // Default parameters to frontend
         $smartyVariables = array(
-            'paymentMethodsResponse' => '{}'
+            'paymentMethodsResponse' => '{}',
+            'selectedInvoiceAddress' => '{}'
         );
 
         // checkout action if available

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -82,11 +82,17 @@ function renderPaymentMethods() {
 
     var notSupportedComponents = ['paypal'];
 
-    var componentBillingAddress = {};
+    var componentBillingAddress = selectedInvoiceAddress;
+
     var countryCode = '';
+    if ('country' in selectedInvoiceAddress) {
+        countryCode = selectedInvoiceAddress.country;
+    }
+    
     var phoneNumber = '';
     var componentDeliveryAddress = {};
-    var componentPersonalDetails
+    var componentPersonalDetails;
+
     if (typeof prestashop !== 'undefined') {
         if (selectedInvoiceAddressId in prestashop.customer.addresses) {
             var invoiceAddress = prestashop.customer.addresses[selectedInvoiceAddressId];

--- a/views/templates/front/adyencheckout.tpl
+++ b/views/templates/front/adyencheckout.tpl
@@ -38,6 +38,9 @@
             {if isset($selectedInvoiceAddressId)}
          data-selected-invoice-address-id="{$selectedInvoiceAddressId|escape:'html':'UTF-8'}"
             {/if}
+            {if isset($selectedInvoiceAddress)}
+                data-selected-invoice-address="{$selectedInvoiceAddress|escape:'html':'UTF-8'}"
+            {/if}
     ></div>
 
 
@@ -69,6 +72,7 @@
         var paymentsDetailsUrl = adyenCheckoutConfiguration.paymentsDetailsUrl;
         var selectedDeliveryAddressId = adyenCheckoutConfiguration.selectedDeliveryAddressId;
         var selectedInvoiceAddressId = adyenCheckoutConfiguration.selectedInvoiceAddressId;
+        var selectedInvoiceAddress = JSON.parse(adyenCheckoutConfiguration.selectedInvoiceAddress)
 
         var ADYEN_CHECKOUT_CONFIG = {
             locale: adyenCheckoutConfiguration.locale,


### PR DESCRIPTION
## Summary
In prestashop 1.6 the `prestashop` variable is not available on the frontend containing the addresses and other details for the cart. In order to render the checkout component correctly we need at least the country code on the frontend.
In the PR the country code and the required billing address details are passed to the frontend and used as default parameters. In case the `prestashop` object is available it will override these default values otherwise it will be used by the components.

## Tested scenarios
Oney on 1.6 and 1.7