### PR TITLE
[PW-3329] Call to undefined method ModuleFrontController::ajaxRender

### DIFF
--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -148,12 +148,12 @@ abstract class FrontController extends \ModuleFrontController
     protected function ajaxRender($value = null, $controller = null, $method = null)
     {
         header('content-type: application/json; charset=utf-8');
-        if ($this->versionChecker->isPrestaShop16()) {
-            $this->ajax = true;
-            parent::ajaxDie($value, $controller, $method);
-        } else {
+        if (method_exists(\ControllerCore::class, 'ajaxRender')) {
             parent::ajaxRender($value, $controller, $method);
             exit;
+        } else {
+            $this->ajax = true;
+            parent::ajaxDie($value, $controller, $method);
         }
     }
 

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -148,7 +148,7 @@ abstract class FrontController extends \ModuleFrontController
     protected function ajaxRender($value = null, $controller = null, $method = null)
     {
         header('content-type: application/json; charset=utf-8');
-        if (method_exists(\ControllerCore::class, 'ajaxRender')) {
+        if (method_exists('\ControllerCore', 'ajaxRender')) {
             parent::ajaxRender($value, $controller, $method);
             exit;
         } else {


### PR DESCRIPTION
## Summary
Use ajaxRender when available otherwise fall back to ajaxDie
ajaxRender has been introduced in prestashop version 1.7.5 and not in
1.7, before 1.7.5 only ajaxDie is available

## Tested scenarios
card payments with 1.7 and 1.6

**Fixed issue**:  <!-- #-prefixed issue number -->
#132 [PW-3329] Call to undefined method ModuleFrontController::ajaxRender 