### PR TITLE
[PW-3448] Fix namespace 'Case mismatch'

### DIFF
--- a/model/Hashing.php
+++ b/model/Hashing.php
@@ -22,7 +22,7 @@
  * See the LICENSE file for more info.
  */
 
-namespace Adyen\PrestaShop\Model;
+namespace Adyen\PrestaShop\model;
 
 /**
  * Class Hashing to manage hash and crypto of user (clients/merchants) passwords.


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixing error: Case mismatch between loaded and declared class names: "Adyen\PrestaShop\model\Hashing" vs "Adyen\PrestaShop\Model\Hashing"

**Fixed issue**:  <!-- #-prefixed issue number -->
#136