### PR TITLE
[PW-3315] Order status changed by notifications even if the payment method has been changed

### DIFF
--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -200,7 +200,10 @@ class NotificationProcessor
                     }
                 }
 
-                $this->adyenPaymentResponse->deletePaymentResponseByCartId($unprocessedNotification['merchant_reference']);
+                $this->adyenPaymentResponse->deletePaymentResponseByCartId(
+                    $unprocessedNotification['merchant_reference']
+                );
+                
                 break;
             case AdyenNotification::OFFER_CLOSED:
                 // Notification success is 'true'
@@ -212,7 +215,10 @@ class NotificationProcessor
                 }
 
 
-                $this->adyenPaymentResponse->deletePaymentResponseByCartId($unprocessedNotification['merchant_reference']);
+                $this->adyenPaymentResponse->deletePaymentResponseByCartId(
+                    $unprocessedNotification['merchant_reference']
+                );
+
                 break;
         }
 

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -198,7 +198,7 @@ class NotificationProcessor
                     }
                 }
 
-                $this->adyenPaymentResponse->deletePaymentResponseByCartId($unprocessedNotification);
+                $this->adyenPaymentResponse->deletePaymentResponseByCartId($unprocessedNotification['merchant_reference']);
                 break;
             case AdyenNotification::OFFER_CLOSED:
                 // Notification success is 'true'
@@ -210,7 +210,7 @@ class NotificationProcessor
                 }
 
 
-                $this->adyenPaymentResponse->deletePaymentResponseByCartId($unprocessedNotification);
+                $this->adyenPaymentResponse->deletePaymentResponseByCartId($unprocessedNotification['merchant_reference']);
                 break;
         }
 

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -141,6 +141,18 @@ class NotificationProcessor
             return false;
         }
 
+        // Ignore notification when the order was paid using another payment module
+        if ($order->module !== 'adyenofficial') {
+            $this->logger->addAdyenNotification(
+                'Notification with entity_id (' .
+                $unprocessedNotification['entity_id'] . ') was ignored during processing the ' .
+                'notifications because the order was NOT paid using the "adyenofficial" Adyen payment module'
+            );
+
+            // Update the notification as done, no need to retry processing it
+            return true;
+        }
+
         // Process notifications based on it's event code
         switch ($unprocessedNotification['event_code']) {
             case AdyenNotification::AUTHORISATION:

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -190,10 +190,12 @@ class NotificationProcessor
                         } else {
                             // Add this log when the notification is ignore because an authorisation success true
                             // notification has already been processed for the same order
-                            $this->logger->addAdyenNotification('Notification with entity_id (' .
+                            $this->logger->addAdyenNotification(
+                                'Notification with entity_id (' .
                                 $unprocessedNotification['entity_id'] . ') was ignored during processing the ' .
                                 'notifications because another Authorisation success = true notification has already ' .
-                                'been processed for the same order.');
+                                'been processed for the same order.'
+                            );
                         }
                     }
                 }
@@ -254,24 +256,28 @@ class NotificationProcessor
         }
 
         if (empty($order)) {
-            $this->logger->error(sprintf(
-                "Order with id: \"%s\" cannot be found while notification with id: \"%s\" was processed.",
-                $notification['merchant_reference'],
-                $notification['entity_id']
-            ));
+            $this->logger->error(
+                sprintf(
+                    "Order with id: \"%s\" cannot be found while notification with id: \"%s\" was processed.",
+                    $notification['merchant_reference'],
+                    $notification['entity_id']
+                )
+            );
             return false;
         }
 
         // Find customer by order id
         $customer = $order->getCustomer();
         if (empty($customer)) {
-            $this->logger->error(sprintf(
-                "Customer with id: \"%s\" cannot be found for order with id: \"%s\" while notification with id:" .
-                " \"%s\" was processed.",
-                $order->id_customer,
-                $order->id,
-                $notification['entity_id']
-            ));
+            $this->logger->error(
+                sprintf(
+                    "Customer with id: \"%s\" cannot be found for order with id: \"%s\" while notification with id:" .
+                    " \"%s\" was processed.",
+                    $order->id_customer,
+                    $order->id,
+                    $notification['entity_id']
+                )
+            );
             return false;
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When processing an Adyen notification, in case the merchant reference is a valid cart number for a non Adyen method paid order then it can change the order itself. A non Adyen method paid order should not be affected by an Adyen notification.

## Tested scenarios
Failed payment with Adyen payment method and successful payment with a non Adyen method 1.7 and 1.6 -> A non Adyen payment method should bump the cart number therefore the notification cannot arrive with the same merchant reference as another payment method, tested with card and redirect payment method (iDeal)

Failed payment with Adyen payment method and successful payment with a non Adyen method 1.7 and 1.6, manually changed the merchant reference to test if the notification can change the order for a non Adyen method.

**Fixed issue**:  <!-- #-prefixed issue number -->
#131 [PW-3315] Order status changed by notifications even if the payment method has been changed 