### PR TITLE
Fix `shopperReference` length

### DIFF
--- a/helper/Data.php
+++ b/helper/Data.php
@@ -38,9 +38,6 @@ use Country;
 use Currency;
 use Exception;
 use FileLogger;
-use Guest;
-use PrestaShopDatabaseException;
-use PrestaShopException;
 use Tools;
 
 class Data
@@ -122,7 +119,7 @@ class Data
         $currency = $currencyData['iso_code'];
         $address = new Address($cart->id_address_invoice);
         $countryCode = Country::getIsoById($address->id_country);
-        $shopperReference = $cart->id_customer;
+        $shopperReference = str_pad($cart->id_customer, 3, '0', STR_PAD_LEFT);
         $shopperLocale = $this->languageAdapter->getLocaleCode($language);
 
         $adyenFields = array(

--- a/service/builder/Customer.php
+++ b/service/builder/Customer.php
@@ -59,7 +59,7 @@ class Customer
     ) {
         // Add shopperReference to identify the unique shoppers in the store by id, necessary for recurring payments
         if (!empty($customerId)) {
-            $request['shopperReference'] = $customerId;
+            $request['shopperReference'] = str_pad($customerId, 3, '0', STR_PAD_LEFT);
         }
 
         // Open invoice methods requires different request format


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
If `shopperReference` is shorter than 3 characters, Adyen will not store payment methods even when asked to do so. This commit fixes this issue by prepending characters to the field without breaking the feature for shoppers who already have cards stored.

## Tested scenarios
<!-- Description of tested scenarios -->
* Payment with credit card while asking to save the payment method.
* See stored payment method in payments list.

**Fixed issue**:  <!-- #-prefixed issue number -->
