### PR TITLE
[PW-2852] Gather integrator in applicationInfo

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -625,19 +625,6 @@ class AdyenOfficial extends PaymentModule
             )
         );
 
-        // Integrator name input
-        $fields_form[0]['form']['input'][] = array(
-            'type' => 'text',
-            'label' => $this->l('Integrator Name'),
-            'name' => 'ADYEN_INTEGRATOR_NAME',
-            'size' => 20,
-            'required' => false,
-            'lang' => false,
-            'hint' => $this->l(
-                'Name of the integrator used. Leave blank if no integrator was utilised.'
-            )
-        );
-
         // Test/Production mode
         $fields_form[0]['form']['input'][] = array(
             'type' => 'radio',
@@ -919,6 +906,31 @@ class AdyenOfficial extends PaymentModule
             'lang' => false,
             'hint' => $this->l(
                 ''
+            )
+        );
+
+        $fields_form[2]['form'] = array(
+            'legend' => array(
+                'title' => $this->l('Developer settings'),
+                'image' => '../img/admin/edit.gif'
+            ),
+            'input' => array(),
+            'submit' => array(
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right'
+            )
+        );
+
+        // Integrator name input
+        $fields_form[2]['form']['input'][] = array(
+            'type' => 'text',
+            'label' => $this->l('Integrator Name'),
+            'name' => 'ADYEN_INTEGRATOR_NAME',
+            'size' => 20,
+            'required' => false,
+            'lang' => false,
+            'hint' => $this->l(
+                'Name of the integrator used. Leave blank if no integrator was utilised.'
             )
         );
 

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -634,7 +634,7 @@ class AdyenOfficial extends PaymentModule
             'required' => false,
             'lang' => false,
             'hint' => $this->l(
-                'Temporary hint'
+                'Name of the integrator used. Leave blank if no integrator was utilised.'
             )
         );
 

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -402,6 +402,7 @@ class AdyenOfficial extends PaymentModule
     {
         $adyenConfigurationNames = array(
             'ADYEN_MERCHANT_ACCOUNT',
+            'ADYEN_INTEGRATOR_NAME',
             'ADYEN_MODE',
             'ADYEN_NOTI_USERNAME',
             'ADYEN_NOTI_PASSWORD',
@@ -484,6 +485,7 @@ class AdyenOfficial extends PaymentModule
         if (Tools::isSubmit('submit' . $this->name)) {
             // get post values
             $merchant_account = (string)Tools::getValue('ADYEN_MERCHANT_ACCOUNT');
+            $integrator_name = (string)Tools::getValue('ADYEN_INTEGRATOR_NAME');
             $mode = (string)Tools::getValue('ADYEN_MODE');
             $notification_username = (string)Tools::getValue('ADYEN_NOTI_USERNAME');
             $notification_password = (string)Tools::getValue('ADYEN_NOTI_PASSWORD');
@@ -504,12 +506,17 @@ class AdyenOfficial extends PaymentModule
                 $output .= $this->displayError($this->l('Invalid Configuration value for Merchant Account'));
             }
 
+            if (!Validate::isGenericName($integrator_name)) {
+                $output .= $this->displayError($this->l('Invalid Configuration value for Integrator Name'));
+            }
+
             if (empty($notification_username) || !Validate::isGenericName($notification_username)) {
                 $output .= $this->displayError($this->l('Invalid Configuration value for Notification Username'));
             }
 
             if ($output == null) {
                 Configuration::updateValue('ADYEN_MERCHANT_ACCOUNT', $merchant_account);
+                Configuration::updateValue('ADYEN_INTEGRATOR_NAME', $integrator_name);
                 Configuration::updateValue('ADYEN_MODE', $mode);
                 Configuration::updateValue('ADYEN_NOTI_USERNAME', $notification_username);
                 Configuration::updateValue('ADYEN_LIVE_ENDPOINT_URL_PREFIX', $live_endpoint_url_prefix);
@@ -615,6 +622,19 @@ class AdyenOfficial extends PaymentModule
             'hint' => $this->l(
                 'In Adyen backoffice you have a company account with one or more merchantaccounts.' .
                 ' Fill in the merchantaccount you want to use for this webshop.'
+            )
+        );
+
+        // Integrator name input
+        $fields_form[0]['form']['input'][] = array(
+            'type' => 'text',
+            'label' => $this->l('Integrator Name'),
+            'name' => 'ADYEN_INTEGRATOR_NAME',
+            'size' => 20,
+            'required' => false,
+            'lang' => false,
+            'hint' => $this->l(
+                'Temporary hint'
             )
         );
 
@@ -939,6 +959,7 @@ class AdyenOfficial extends PaymentModule
         if (Tools::isSubmit('submit' . $this->name)) {
             // get settings from post because post can give errors and you want to keep values
             $merchant_account = (string)Tools::getValue('ADYEN_MERCHANT_ACCOUNT');
+            $integrator_name = (string)Tools::getValue('ADYEN_INTEGRATOR_NAME');
             $mode = (string)Tools::getValue('ADYEN_MODE');
             $notification_username = (string)Tools::getValue('ADYEN_NOTI_USERNAME');
             $cron_job_token = Tools::getValue('ADYEN_CRONJOB_TOKEN');
@@ -951,6 +972,7 @@ class AdyenOfficial extends PaymentModule
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
         } else {
             $merchant_account = Configuration::get('ADYEN_MERCHANT_ACCOUNT');
+            $integrator_name = Configuration::get('ADYEN_INTEGRATOR_NAME');
             $mode = Configuration::get('ADYEN_MODE');
             $notification_username = Configuration::get('ADYEN_NOTI_USERNAME');
             $cron_job_token = $cronjobToken;
@@ -966,6 +988,7 @@ class AdyenOfficial extends PaymentModule
 
         // Load current value
         $helper->fields_value['ADYEN_MERCHANT_ACCOUNT'] = $merchant_account;
+        $helper->fields_value['ADYEN_INTEGRATOR_NAME'] = $integrator_name;
         $helper->fields_value['ADYEN_MODE'] = $mode;
         $helper->fields_value['ADYEN_NOTI_USERNAME'] = $notification_username;
         $helper->fields_value['ADYEN_CRONJOB_TOKEN'] = $cron_job_token;

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -506,7 +506,7 @@ class AdyenOfficial extends PaymentModule
                 $output .= $this->displayError($this->l('Invalid Configuration value for Merchant Account'));
             }
 
-            if (!Validate::isGenericName($integrator_name)) {
+            if (!Validate::isGenericName($integrator_name) || preg_match('/[^A-Za-z0-9]/', $integrator_name)) {
                 $output .= $this->displayError($this->l('Invalid Configuration value for Integrator Name'));
             }
 

--- a/service/Client.php
+++ b/service/Client.php
@@ -63,7 +63,7 @@ class Client extends \Adyen\Client
         $this->setXApiKey($apiKey);
         $this->setAdyenPaymentSource($configuration->moduleName, $configuration->moduleVersion);
         $this->setMerchantApplication($configuration->moduleName, $configuration->moduleVersion);
-        $this->setExternalPlatform("PrestaShop", _PS_VERSION_);
+        $this->setExternalPlatform("PrestaShop", _PS_VERSION_, $configuration->integratorName);
         $this->setEnvironment($configuration->adyenMode, $configuration->liveEndpointPrefix);
 
         $this->setLogger($logger);

--- a/service/adapter/classes/Configuration.php
+++ b/service/adapter/classes/Configuration.php
@@ -71,6 +71,11 @@ class Configuration
     public $moduleName;
 
     /**
+     * @var string
+     */
+    public $integratorName;
+
+    /**
      * @var Logger
      */
     private $logger;
@@ -92,6 +97,7 @@ class Configuration
         $this->liveEndpointPrefix = \Configuration::get('ADYEN_LIVE_ENDPOINT_URL_PREFIX');
         $this->moduleVersion = '3.2.1';
         $this->moduleName = 'adyen-prestashop';
+        $this->integratorName = \Configuration::get('ADYEN_INTEGRATOR_NAME', null, null, null, "");
     }
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Allow the merchant to specify his integrator name. If this field is populated, it is added to the request under the applicationInfo. If not, the field is not sent .

## Tested scenarios
<!-- Description of tested scenarios -->
Tested both scenarios on both 1.6 and 1.7.
Requests with an integrator setting sent the Integrator correctly in the request.
Requests without an integrator setting sent no Integrator/empty string.

