### PR TITLE
[PW-3316] Incoherence between order status from notifications system and payment response handling

### DIFF
--- a/model/AdyenNotification.php
+++ b/model/AdyenNotification.php
@@ -182,13 +182,8 @@ class AdyenNotification extends AbstractModel
 
         // do this to set both fields in the correct timezone
         $date = new \DateTime();
-        if ($data['event_code'] === self::AUTHORISATION && $data['success'] === 'false') {
-            $createdAt = new \DateTime();
-            $data['created_at'] = $createdAt->add(new \DateInterval("PT1H"))->format('Y-m-d H:i:s');
-        } else {
-            $data['created_at'] = $date->format('Y-m-d H:i:s');
-        }
 
+        $data['created_at'] = $this->getCreatedAtDate($data)->format('Y-m-d H:i:s');
         $data['updated_at'] = $date->format('Y-m-d H:i:s');
 
         $this->dbInstance->insert(self::$tableName, $data);
@@ -231,5 +226,21 @@ class AdyenNotification extends AbstractModel
             . ' AND `done` = 1';
 
         return $this->dbInstance->executeS($sql);
+    }
+
+    /**
+     * @param $data
+     * @return \DateTime
+     */
+    private function getCreatedAtDate($data): \DateTime
+    {
+        $date = new \DateTime();
+        // If authorisation w/ false success OR offer closed, delay by an hour
+        if (($data['event_code'] === self::AUTHORISATION && $data['success'] === 'false') ||
+            $data['event_code'] === self::OFFER_CLOSED) {
+            $date->add(new \DateInterval("PT1H"));
+        }
+
+        return $date;
     }
 }

--- a/model/AdyenNotification.php
+++ b/model/AdyenNotification.php
@@ -232,7 +232,7 @@ class AdyenNotification extends AbstractModel
      * @param $data
      * @return \DateTime
      */
-    private function getCreatedAtDate($data): \DateTime
+    private function getCreatedAtDate($data)
     {
         $date = new \DateTime();
         // If authorisation w/ false success OR offer closed, delay by an hour

--- a/model/AdyenNotification.php
+++ b/model/AdyenNotification.php
@@ -182,7 +182,13 @@ class AdyenNotification extends AbstractModel
 
         // do this to set both fields in the correct timezone
         $date = new \DateTime();
-        $data['created_at'] = $date->format('Y-m-d H:i:s');
+        if ($data['event_code'] === self::AUTHORISATION && $data['success'] === 'false') {
+            $createdAt = new \DateTime();
+            $data['created_at'] = $createdAt->add(new \DateInterval("PT1H"))->format('Y-m-d H:i:s');
+        } else {
+            $data['created_at'] = $date->format('Y-m-d H:i:s');
+        }
+
         $data['updated_at'] = $date->format('Y-m-d H:i:s');
 
         $this->dbInstance->insert(self::$tableName, $data);

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -181,10 +181,8 @@ class NotificationProcessor
                 } else { // Notification success is 'false'
                     // Order state is not canceled yet
                     if ($order->getCurrentState() !== \Configuration::get('PS_OS_CANCELED')) {
-                        // No previous authorisation notification was processed before
-                        if (!$this->hasProcessedAuthorisationSuccessNotification(
-                            $unprocessedNotification['merchant_reference']
-                        )) {
+                        // If order has a non final status, set to cancelled
+                        if ($this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
                             // Moves order to canceled
                             $order->setCurrentState(\Configuration::get('PS_OS_CANCELED'));
                         } else {
@@ -192,9 +190,8 @@ class NotificationProcessor
                             // notification has already been processed for the same order
                             $this->logger->addAdyenNotification(
                                 'Notification with entity_id (' .
-                                $unprocessedNotification['entity_id'] . ') was ignored during processing the ' .
-                                'notifications because another Authorisation success = true notification has already ' .
-                                'been processed for the same order.'
+                                $unprocessedNotification['entity_id'] . ') was ignored during processing ' .
+                                'because the order status is already in a final state.'
                             );
                         }
                     }
@@ -207,8 +204,7 @@ class NotificationProcessor
                 break;
             case AdyenNotification::OFFER_CLOSED:
                 // Notification success is 'true' AND current status is a non-final one
-                if ('true' === $unprocessedNotification['success'] &&
-                    $this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
+                if ('true' === $unprocessedNotification['success']) {
                     // Moves order to canceled if order status is waiting for payment
                     if ($order->getCurrentState() === \Configuration::get('ADYEN_OS_WAITING_FOR_PAYMENT')) {
                         $order->setCurrentState(\Configuration::get('PS_OS_CANCELED'));
@@ -321,34 +317,6 @@ class NotificationProcessor
         }
 
         return true;
-    }
-
-    /**
-     * Returns true if an Authorisation notification with success = true has already been processed before for the same
-     * merchant_reference
-     *
-     * @param $merchantReference
-     * @return bool
-     */
-    private function hasProcessedAuthorisationSuccessNotification($merchantReference)
-    {
-        $notificationModel = new AdyenNotification();
-
-        $processedNotifications = $notificationModel->getProcessedNotificationsByMerchantReference($merchantReference);
-
-        if (empty($processedNotifications)) {
-            return false;
-        }
-
-        foreach ($processedNotifications as $processedNotification) {
-            if (AdyenNotification::AUTHORISATION === $processedNotification['event_code'] &&
-                'true' === $processedNotification['success']
-            ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -206,8 +206,9 @@ class NotificationProcessor
                 
                 break;
             case AdyenNotification::OFFER_CLOSED:
-                // Notification success is 'true'
-                if ('true' === $unprocessedNotification['success']) {
+                // Notification success is 'true' AND current status is a non-final one
+                if ('true' === $unprocessedNotification['success'] &&
+                    $this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
                     // Moves order to canceled if order status is waiting for payment
                     if ($order->getCurrentState() === \Configuration::get('ADYEN_OS_WAITING_FOR_PAYMENT')) {
                         $order->setCurrentState(\Configuration::get('PS_OS_CANCELED'));

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -203,7 +203,7 @@ class NotificationProcessor
                 
                 break;
             case AdyenNotification::OFFER_CLOSED:
-                // Notification success is 'true' AND current status is a non-final one
+                // Notification success is 'true' AND current status is ADYEN_OS_WAITING_FOR_PAYMENT
                 if ('true' === $unprocessedNotification['success']) {
                     // Moves order to canceled if order status is waiting for payment
                     if ($order->getCurrentState() === \Configuration::get('ADYEN_OS_WAITING_FOR_PAYMENT')) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Always prioritize the data received from the payment details call, over the data received in the notification call.
- Delay the processing of an `authorization w/success = false` notification by an hour 

## Tested scenarios
1. Successful authorization notification processed after order is already set to successful. No changes.
2. Not successful authorization notification processed after order is already set to successful. Order status **not** updated
3. Not successful authorization notification processed after order is already set to cancelled. No changes.


**Fixed issue**:  <!-- #-prefixed issue number -->
#130 
