### PR TITLE
[PW-2767] - New paypal integration 

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1180,7 +1180,7 @@ class AdyenOfficial extends PaymentModule
         );
 
         // List of payment methods that needs to show the pay button from the component
-        $paymentMethodsWithPayButtonFromComponent = json_encode(array('paywithgoogle', 'applepay'));
+        $paymentMethodsWithPayButtonFromComponent = json_encode(array('paywithgoogle', 'applepay', 'paypal'));
 
         // All payment method specific configuration
         $paymentMethodsConfigurations = json_encode(

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -227,9 +227,10 @@ abstract class FrontController extends \ModuleFrontController
                 // PaymentResponse can be deleted
                 $this->adyenPaymentResponseModel->deletePaymentResponseByCartId($cart->id);
 
-                // In case of refused payment there is no order created and the cart needs to be cloned and reinitiated
+                // In case of refused/cancelled payment there is no order created and the cart needs to be cloned and
+            // reinitiated
                 $this->cartService->cloneCurrentCart($this->context, $cart);
-                $this->logger->error("The payment was refused, id:  " . $cart->id);
+                $this->logger->error('The payment was ' . strtolower($resultCode) . ', id:  ' . $cart->id);
 
                 if ($cancelled) {
                     $message = $this->l('The payment was cancelled by the customer');

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -229,7 +229,7 @@ abstract class FrontController extends \ModuleFrontController
                 // In case of refused/cancelled payment there is no order created and the cart needs to be cloned and
                 // reinitiated
                 $this->cartService->cloneCurrentCart($this->context, $cart);
-                $this->logger->error('The payment was ' . strtolower($resultCode) . ', id:  ' . $cart->id);
+                $this->logger->error('The payment was ' . strtolower($resultCode) . ', with cart id:  ' . $cart->id);
 
                 if ($resultCode === 'Cancelled') {
                     $message = $this->l('The payment was cancelled by the customer');

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -337,11 +337,12 @@ abstract class FrontController extends \ModuleFrontController
                 );
 
                 if ($isAjax) {
+                    $message = $this->l('There was an error with the payment method, please choose another one');
                     $this->ajaxRender(
                         $this->helperData->buildControllerResponseJson(
                             'error',
                             array(
-                                'message' => $this->l('There was an error with the payment method, please choose another one'),
+                                'message' => $message,
                             )
                         )
                     );

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -173,7 +173,7 @@ abstract class FrontController extends \ModuleFrontController
      * @param $cancelled
      * @throws AdyenException
      */
-    protected function handlePaymentsResponse($response, $cart, $customer, $isAjax, $cancelled = false)
+    protected function handlePaymentsResponse($response, $cart, $customer, $isAjax)
     {
         $resultCode = $response['resultCode'];
 
@@ -228,11 +228,11 @@ abstract class FrontController extends \ModuleFrontController
                 $this->adyenPaymentResponseModel->deletePaymentResponseByCartId($cart->id);
 
                 // In case of refused/cancelled payment there is no order created and the cart needs to be cloned and
-            // reinitiated
+                // reinitiated
                 $this->cartService->cloneCurrentCart($this->context, $cart);
                 $this->logger->error('The payment was ' . strtolower($resultCode) . ', id:  ' . $cart->id);
 
-                if ($cancelled) {
+                if ($resultCode === 'Cancelled') {
                     $message = $this->l('The payment was cancelled by the customer');
                 } else {
                     $message = $this->l('The payment was refused');

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -232,10 +232,9 @@ abstract class FrontController extends \ModuleFrontController
                 $this->logger->error("The payment was refused, id:  " . $cart->id);
 
                 if ($cancelled) {
-                    // TODO translate the message
-                    $message = "The payment was cancelled by the customer";
+                    $message = $this->l('The payment was cancelled by the customer');
                 } else {
-                    $message = "The payment was refused";
+                    $message = $this->l('The payment was refused');
                 }
 
                 if ($isAjax) {
@@ -342,9 +341,7 @@ abstract class FrontController extends \ModuleFrontController
                         $this->helperData->buildControllerResponseJson(
                             'error',
                             array(
-                                'message' => $this->l(
-                                    "There was an error with the payment method, please choose another one."
-                                )
+                                'message' => $this->l('There was an error with the payment method, please choose another one'),
                             )
                         )
                     );
@@ -379,7 +376,7 @@ abstract class FrontController extends \ModuleFrontController
                         $this->helperData->buildControllerResponseJson(
                             'error',
                             array(
-                                'message' => $this->l("Unsupported result code:") . "{" . $response['resultCode'] . "}"
+                                'message' => $this->l('Unsupported result code:') . "{" . $response['resultCode'] . "}"
                             )
                         )
                     );

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -170,7 +170,6 @@ abstract class FrontController extends \ModuleFrontController
      * @param $cart
      * @param $customer
      * @param $isAjax
-     * @param $cancelled
      * @throws AdyenException
      */
     protected function handlePaymentsResponse($response, $cart, $customer, $isAjax)

--- a/controllers/front/PaymentsDetails.php
+++ b/controllers/front/PaymentsDetails.php
@@ -45,6 +45,7 @@ class AdyenOfficialPaymentsDetailsModuleFrontController extends FrontController
     public function postProcess()
     {
         $payload = $_REQUEST;
+        $cancelled = false;
 
         $cart = $this->getCurrentCart();
         $paymentResponse = $this->adyenPaymentResponseModel->getPaymentResponseByCartId($cart->id);
@@ -60,6 +61,11 @@ class AdyenOfficialPaymentsDetailsModuleFrontController extends FrontController
                     )
                 )
             );
+        }
+
+        // Check if customer cancelled the payment
+        if (!empty($payload['cancelled'])) {
+            $cancelled = true;
         }
 
         // Get validated state data
@@ -100,6 +106,6 @@ class AdyenOfficialPaymentsDetailsModuleFrontController extends FrontController
             );
         }
 
-        $this->handlePaymentsResponse($result, $cart, $customer, true);
+        $this->handlePaymentsResponse($result, $cart, $customer, true, $cancelled);
     }
 }

--- a/controllers/front/PaymentsDetails.php
+++ b/controllers/front/PaymentsDetails.php
@@ -45,7 +45,6 @@ class AdyenOfficialPaymentsDetailsModuleFrontController extends FrontController
     public function postProcess()
     {
         $payload = $_REQUEST;
-        $cancelled = false;
 
         $cart = $this->getCurrentCart();
         $paymentResponse = $this->adyenPaymentResponseModel->getPaymentResponseByCartId($cart->id);
@@ -61,11 +60,6 @@ class AdyenOfficialPaymentsDetailsModuleFrontController extends FrontController
                     )
                 )
             );
-        }
-
-        // Check if customer cancelled the payment
-        if (!empty($payload['cancelled'])) {
-            $cancelled = true;
         }
 
         // Get validated state data
@@ -106,6 +100,6 @@ class AdyenOfficialPaymentsDetailsModuleFrontController extends FrontController
             );
         }
 
-        $this->handlePaymentsResponse($result, $cart, $customer, true, $cancelled);
+        $this->handlePaymentsResponse($result, $cart, $customer, true);
     }
 }

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -520,7 +520,6 @@ jQuery(document).ready(function() {
         function handleOnCancel(state, component) {
             processPaymentsDetails({
                 'details': { 'orderID': state.orderID },
-                'cancelled': true,
             }).done(function(responseJSON) {
                 processControllerResponse(responseJSON, getSelectedPaymentMethod(), component);
             });

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -518,6 +518,7 @@ jQuery(document).ready(function() {
         }
 
         function handleOnCancel(state, component) {
+            // TODO: Stop creating details manually when FOC-42190 is released
             processPaymentsDetails({
                 'details': { 'orderID': state.orderID },
             }).done(function(responseJSON) {

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -526,8 +526,6 @@ jQuery(document).ready(function() {
             }).done(function(responseJSON) {
                 processControllerResponse(responseJSON, getSelectedPaymentMethod(), component);
             });
-            // TODO do the same function handleOnAdditionalDetails(state)
-            // and don't forget to enrich the request with `cancelled`: true
         }
 
         function getFormComponent(paymentForm) {

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -448,8 +448,8 @@ jQuery(document).ready(function() {
                 configuration);
 
             try {
-                if (handleActionComponents.includes(component.type)) {
-                    component.handleAction();
+                if (handleActionComponents.includes(action.paymentMethodType)) {
+                    component.handleAction(action);
                 } else {
                     actionComponent.createFromAction(action).mount('#actionContainer');
                 }
@@ -497,13 +497,22 @@ jQuery(document).ready(function() {
 
         function handleOnClick(resolve, reject) {
             const paymentMethodContainer = this.paymentForm.closest('.adyen-payment');
+            const paymentMethodType = paymentMethodContainer.data('local-payment-method');
             // Show message if button is disabled else if not in progress, hide and resolve
             if (prestaShopPlaceOrderButton.prop('disabled') && !isPlaceOrderInProgress()) {
                 showRequiredConditionsInfoMessage(paymentMethodContainer);
-                reject(new Error('Terms of service not agreed'));
+                if (paymentMethodType === 'paypal') {
+                    return false;
+                } else {
+                    reject(new Error('Terms of service not agreed'));
+                }
             } else if (!isPlaceOrderInProgress()) {
                 hideInfoMessage(paymentMethodContainer);
-                resolve();
+                if (paymentMethodType === 'paypal') {
+                    return true;
+                } else {
+                    resolve();
+                }
             }
         }
 

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -108,7 +108,7 @@ jQuery(document).ready(function() {
         var placeOrderAllowed;
         var popupModal;
 
-        var notSupportedComponents = ['giropay'];
+        var skipComponents = ['giropay'];
         const handleActionComponents = ['paypal'];
 
         var componentBillingAddress = selectedInvoiceAddress;
@@ -235,7 +235,7 @@ jQuery(document).ready(function() {
         function renderPaymentComponent(
             paymentMethod, paymentMethodContainer, paymentForm) {
 
-            if (notSupportedComponents.includes(paymentMethod.type)) {
+            if (skipComponents.includes(paymentMethod.type)) {
                 return;
             }
 

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -108,7 +108,8 @@ jQuery(document).ready(function() {
         var placeOrderAllowed;
         var popupModal;
 
-        var notSupportedComponents = ['paypal', 'giropay'];
+        var notSupportedComponents = ['giropay'];
+        const handleActionComponents = ['paypal'];
 
         var componentBillingAddress = selectedInvoiceAddress;
 
@@ -378,11 +379,11 @@ jQuery(document).ready(function() {
                     'isAjax': true,
                 });
 
-                processPayment(paymentData, paymentForm);
+                processPayment(paymentData, paymentForm, component);
             });
         }
 
-        function processPayment(data, paymentForm) {
+        function processPayment(data, paymentForm, component) {
             var paymentProcessUrl = paymentForm.attr('action');
 
             $.ajax({
@@ -391,7 +392,7 @@ jQuery(document).ready(function() {
                 data: data,
                 dataType: 'json',
                 success: function(response) {
-                    processControllerResponse(response, paymentForm);
+                    processControllerResponse(response, paymentForm, component);
                 },
                 error: function(response) {
                     paymentForm.find('.error-container').
@@ -413,7 +414,7 @@ jQuery(document).ready(function() {
             });
         }
 
-        function processControllerResponse(response, paymentForm) {
+        function processControllerResponse(response, paymentForm, component) {
             switch (response.action) {
                 case 'error':
                     // show error message
@@ -426,7 +427,7 @@ jQuery(document).ready(function() {
                     window.location.replace(response.redirectUrl);
                     break;
                 case 'action':
-                    renderActionComponent(response.response);
+                    renderActionComponent(response.response, component);
                     break;
                 default:
                     // show error message
@@ -435,7 +436,7 @@ jQuery(document).ready(function() {
             }
         }
 
-        function renderActionComponent(action) {
+        function renderActionComponent(action, component) {
             // TODO remove when fix is rolled out in a new checkout component version
             delete configuration.data;
 
@@ -447,8 +448,11 @@ jQuery(document).ready(function() {
                 configuration);
 
             try {
-                actionComponent.createFromAction(action).
-                    mount('#actionContainer');
+                if (handleActionComponents.includes(component.type)) {
+                    component.handleAction();
+                } else {
+                    actionComponent.createFromAction(action).mount('#actionContainer');
+                }
             } catch (e) {
                 console.log(e);
                 hidePopup();

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -517,23 +517,13 @@ jQuery(document).ready(function() {
             }
         }
 
-        function handleOnCancel(state) {
-            hidePopup();
-            const component = getFormComponent(this.paymentForm);
+        function handleOnCancel(state, component) {
             processPaymentsDetails({
                 'details': { 'orderID': state.orderID },
                 'cancelled': true,
             }).done(function(responseJSON) {
                 processControllerResponse(responseJSON, getSelectedPaymentMethod(), component);
             });
-        }
-
-        function getFormComponent(paymentForm) {
-            const paymentMethodContainer = getFormPaymentMethodContainer(paymentForm);
-            const paymentMethodType = paymentMethodContainer.data('local-payment-method');
-            const paymentMethod = paymentMethods.find((paymentMethod) => paymentMethod.type === paymentMethodType);
-            return renderPaymentComponent(paymentMethod, paymentMethodContainer,
-                paymentForm);
         }
 
         function getFormPaymentMethodContainer(paymentForm) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

New paypal integration on prestashop. The main difference to other payment methods was that we were required to use the `handleAction` and not the `createFromAction`.

The other main change was to implement the `onCancel` function which sends a request to the payment details endpoint with an additional parameter. Because of this parameter, the back end will set the order to cancelled and return an appropriate message.

## Tested scenarios
Happy flow on 1.6 and 1.7
Unhappy flow on 1.6 and 1.7

