### PR TITLE
[PW-3952] Validate cart value and currency before each /payments and /payments/details request

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -110,7 +110,7 @@ class AdyenOfficial extends PaymentModule
     public function __construct()
     {
         $this->name = 'adyenofficial';
-        $this->version = '3.2.1';
+        $this->version = '3.3.0';
         $this->tab = 'payments_gateways';
         $this->author = 'Adyen';
         $this->bootstrap = true;

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -395,7 +395,7 @@ class AdyenOfficial extends PaymentModule
     }
 
     /**
-     * Create a new order status: "waiting for payment"
+     * Create a new order status: "payment needs attention"
      *
      * @return mixed
      * @throws PrestaShopDatabaseException

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -115,7 +115,7 @@ class AdyenOfficial extends PaymentModule
         $this->author = 'Adyen';
         $this->bootstrap = true;
         $this->display = 'view';
-        $this->ps_versions_compliancy = array('min' => '1.6', 'max' => _PS_VERSION_);
+        $this->ps_versions_compliancy = array('min' => '1.6.1', 'max' => _PS_VERSION_);
         $this->currencies = true;
 
         $this->helper_data = \Adyen\PrestaShop\service\adapter\classes\ServiceLocator::get(

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -333,6 +333,8 @@ class AdyenOfficial extends PaymentModule
         $query = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'adyen_payment_response` (
             `entity_id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT \'Adyen Payment Entity ID\',
             `id_cart` int(11) DEFAULT NULL COMMENT \'Prestashop cart id\',
+            `request_amount` int COMMENT \'Payment amount in the request\',
+            `request_currency` varchar(3) COMMENT \'Payment currency in the request\',
             `result_code` varchar(255) DEFAULT NULL COMMENT \'Result code\',
             `response` text COMMENT \'Response\',
             `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT \'Created At\',

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -217,7 +217,6 @@ abstract class FrontController extends \ModuleFrontController
         // Based on the result code start different payment flows
         switch ($resultCode) {
             case 'Authorised':
-
                 $orderStatus = \Configuration::get('PS_OS_PAYMENT');
                 if ($orderNeedsAttention) {
                     $orderStatus = \Configuration::get('ADYEN_OS_PAYMENT_NEEDS_ATTENTION');
@@ -283,12 +282,15 @@ abstract class FrontController extends \ModuleFrontController
 
                 break;
             case 'RedirectShopper':
+                // Create an ordder for each redirectShopper payments with the state of ADYEN_OS_WAITING_FOR_PAYMENT
                 $this->createOrUpdateOrder(
                     $cart,
                     $extraVars,
                     $customer,
                     \Configuration::get('ADYEN_OS_WAITING_FOR_PAYMENT')
                 );
+
+                // Handle the rest the same way as the cases below
             case 'IdentifyShopper':
             case 'ChallengeShopper':
             case 'Pending':
@@ -323,7 +325,6 @@ abstract class FrontController extends \ModuleFrontController
                 );
 
                 if (\Validate::isLoadedObject($customer)) {
-
                     $orderStatus = \Configuration::get('ADYEN_OS_WAITING_FOR_PAYMENT');
                     if ($orderNeedsAttention) {
                         $orderStatus = \Configuration::get('ADYEN_OS_PAYMENT_NEEDS_ATTENTION');

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -167,12 +167,13 @@ abstract class FrontController extends \ModuleFrontController
 
     /**
      * @param $response
-     * @param $cart
+     * @param \Cart $cart
      * @param $customer
      * @param $isAjax
+     * @param array $paymentRequest
      * @throws AdyenException
      */
-    protected function handlePaymentsResponse($response, $cart, $customer, $isAjax)
+    protected function handleAdyenApiResponse($response, \Cart $cart, $customer, $isAjax, $paymentRequest = array())
     {
         $resultCode = $response['resultCode'];
 

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -255,7 +255,6 @@ abstract class FrontController extends \ModuleFrontController
                 if ($cart->OrderExists() !== false) {
                     $order = $this->orderAdapter->getOrderByCartId($cart->id);
                     if (\Validate::isLoadedObject($order)) {
-                        //$orderPayment = \OrderPaymentCore::getByOrderReference($order->reference);
                         $order->setCurrentState(\Configuration::get('PS_OS_CANCELED'));
                     } else {
                         $this->logger->addError('Order cannot be loaded for cart id: ' . $cart->id);

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -289,7 +289,7 @@ abstract class FrontController extends \ModuleFrontController
 
                 break;
             case 'RedirectShopper':
-                // Create an ordder for each redirectShopper payments with the state of ADYEN_OS_WAITING_FOR_PAYMENT
+                // Create an order for each redirectShopper payments with the state of ADYEN_OS_WAITING_FOR_PAYMENT
                 $this->createOrUpdateOrder(
                     $cart,
                     $extraVars,

--- a/controllers/front/Payment.php
+++ b/controllers/front/Payment.php
@@ -203,7 +203,7 @@ class AdyenOfficialPaymentModuleFrontController extends FrontController
             );
         }
 
-        $this->handlePaymentsResponse($response, $cart, $customer, $isAjax);
+        $this->handleAdyenApiResponse($response, $cart, $customer, $isAjax, $request);
     }
 
     /**

--- a/controllers/front/PaymentsDetails.php
+++ b/controllers/front/PaymentsDetails.php
@@ -100,6 +100,6 @@ class AdyenOfficialPaymentsDetailsModuleFrontController extends FrontController
             );
         }
 
-        $this->handlePaymentsResponse($result, $cart, $customer, true);
+        $this->handleAdyenApiResponse($result, $cart, $customer, true);
     }
 }

--- a/controllers/front/Result.php
+++ b/controllers/front/Result.php
@@ -74,6 +74,6 @@ class AdyenOfficialResultModuleFrontController extends FrontController
         $this->adyenPaymentResponseModel->deletePaymentResponseByCartId($cart->id);
 
         $customer = new \Customer($cart->id_customer);
-        $this->handlePaymentsResponse($response, $cart, $customer, false);
+        $this->handleAdyenApiResponse($response, $cart, $customer, false);
     }
 }

--- a/model/AdyenPaymentResponse.php
+++ b/model/AdyenPaymentResponse.php
@@ -37,8 +37,13 @@ class AdyenPaymentResponse extends AbstractModel
      * @param null $requestCurrency
      * @return bool
      */
-    public function insertOrUpdatePaymentResponse($cartId, $resultCode, $response, $requestAmount = null, $requestCurrency = null)
-    {
+    public function insertOrUpdatePaymentResponse(
+        $cartId,
+        $resultCode,
+        $response,
+        $requestAmount = null,
+        $requestCurrency = null
+    ) {
         $data = array(
             'result_code' => pSQL($resultCode),
             'response' => pSQL($this->jsonEncodeIfArray($response))
@@ -81,8 +86,8 @@ class AdyenPaymentResponse extends AbstractModel
      */
     public function getPaymentByCartId($cartId)
     {
-        $sql = 'SELECT `request_amount`, `request_currency`, `result_code`, `response` FROM ' . _DB_PREFIX_ . self::$tableName
-            . ' WHERE `id_cart` = "' . (int)$cartId . '"';
+        $sql = 'SELECT `request_amount`, `request_currency`, `result_code`, `response` FROM ' .
+            _DB_PREFIX_ . self::$tableName . ' WHERE `id_cart` = "' . (int)$cartId . '"';
 
         $row = $this->dbInstance->getRow($sql, false);
 

--- a/model/AdyenPaymentResponse.php
+++ b/model/AdyenPaymentResponse.php
@@ -24,6 +24,7 @@
 
 namespace Adyen\PrestaShop\model;
 
+// TODO Rename database table to AdyenPayment
 class AdyenPaymentResponse extends AbstractModel
 {
     private static $tableName = 'adyen_payment_response';
@@ -32,14 +33,24 @@ class AdyenPaymentResponse extends AbstractModel
      * @param $cartId
      * @param $resultCode
      * @param $response
+     * @param null $requestAmount
+     * @param null $requestCurrency
      * @return bool
      */
-    public function insertOrUpdatePaymentResponse($cartId, $resultCode, $response)
+    public function insertOrUpdatePaymentResponse($cartId, $resultCode, $response, $requestAmount = null, $requestCurrency = null)
     {
         $data = array(
             'result_code' => pSQL($resultCode),
             'response' => pSQL($this->jsonEncodeIfArray($response))
         );
+
+        if (null !== $requestAmount) {
+            $data['request_amount'] = pSQL((int)$requestAmount);
+        }
+
+        if (null !== $requestCurrency) {
+            $data['request_currency'] = pSQL($requestCurrency);
+        }
 
         if ($this->getPaymentResponseByCartId($cartId)) {
             return $this->updatePaymentResponseByCartId($cartId, $data);
@@ -62,6 +73,24 @@ class AdyenPaymentResponse extends AbstractModel
         return $this->jsonDecodeIfJson(
             $this->dbInstance->getValue($sql)
         );
+    }
+
+    /**
+     * @param $cartId
+     * @return array|bool|object|null
+     */
+    public function getPaymentByCartId($cartId)
+    {
+        $sql = 'SELECT `request_amount`, `request_currency`, `result_code`, `response` FROM ' . _DB_PREFIX_ . self::$tableName
+            . ' WHERE `id_cart` = "' . (int)$cartId . '"';
+
+        $row = $this->dbInstance->getRow($sql, false);
+
+        if (!empty($row)) {
+            $row['response'] = $this->jsonDecodeIfJson($row['response']);
+        }
+
+        return $row;
     }
 
     /**

--- a/service/adapter/classes/Configuration.php
+++ b/service/adapter/classes/Configuration.php
@@ -95,7 +95,7 @@ class Configuration
         $this->encryptedApiKey = $this->getEncryptedAPIKey();
         $this->clientKey = $this->getClientKey();
         $this->liveEndpointPrefix = \Configuration::get('ADYEN_LIVE_ENDPOINT_URL_PREFIX');
-        $this->moduleVersion = '3.2.1';
+        $this->moduleVersion = '3.3.0';
         $this->moduleName = 'adyen-prestashop';
         $this->integratorName = \Configuration::get('ADYEN_INTEGRATOR_NAME', null, null, null, "");
     }

--- a/upgrade/upgrade-3.3.0.php
+++ b/upgrade/upgrade-3.3.0.php
@@ -50,7 +50,8 @@ function alterAdyenPaymentResponseTable()
     $db = Db::getInstance();
     $query = 'ALTER TABLE `' . _DB_PREFIX_ . 'adyen_payment_response`
             ADD COLUMN `request_amount` int NOT NULL COMMENT \'Payment amount in the request\' AFTER `id_cart`,
-            ADD COLUMN `request_currency` varchar(3) NOT NULL COMMENT \'Payment currency in the request\' AFTER `request_amount`';
+            ADD COLUMN `request_currency` varchar(3) NOT NULL COMMENT \'Payment currency in the request\'
+                AFTER `request_amount`';
 
     return $db->execute($query);
 }

--- a/upgrade/upgrade-3.3.0.php
+++ b/upgrade/upgrade-3.3.0.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop plugin
+ *
+ * @author Adyen BV <support@adyen.com>
+ * @copyright (c) 2020 Adyen B.V.
+ * @license https://opensource.org/licenses/MIT MIT license
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+// This file declares a function and checks if PrestaShop is loaded to follow
+// PrestaShop's good practices, which breaks a PSR1 element.
+//phpcs:disable PSR1.Files.SideEffects
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * This function is automatically called on version upgrades.
+ *
+ * @param AdyenOfficial $module
+ *
+ * @return bool
+ */
+function upgrade_module_3_3_0(AdyenOfficial $module)
+{
+    return $module->createPaymentNeedsAttentionOrderStatus() && alterAdyenPaymentResponseTable();
+}
+
+/**
+ * @return bool
+ */
+function alterAdyenPaymentResponseTable()
+{
+    $db = Db::getInstance();
+    $query = 'ALTER TABLE `' . _DB_PREFIX_ . 'adyen_payment_response`
+            ADD COLUMN `request_amount` int NOT NULL COMMENT \'Payment amount in the request\' AFTER `id_cart`,
+            ADD COLUMN `request_currency` varchar(3) NOT NULL COMMENT \'Payment currency in the request\' AFTER `request_amount`';
+
+    return $db->execute($query);
+}


### PR DESCRIPTION
## Summary
Add ADYEN_OS_PAYMENT_NEEDS_ATTENTION new order status
Alter adyen_payment_response to add request_amount and request_currency 
Create waiting for payment orders for RedirectShopper methods
Avoid creating order in case the cart amount or currency has changed during the payment process
In case the payment is verified and the cart has changed, flag the order as needs attention

**Fixed issue**:
#151 [PW-3952] Bank amount different of prestashop total paid amount 