### PR TITLE
[PW-3960] - Verify the paid amount during notification processing 

### DIFF
--- a/controllers/admin/AdminAdyenOfficialPrestashopCronController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopCronController.php
@@ -110,7 +110,8 @@ class AdminAdyenOfficialPrestashopCronController extends \ModuleAdminController
             $this->logger,
             \Context::getContext(),
             new AdyenPaymentResponse(),
-            new OrderService()
+            new OrderService(),
+            new \Adyen\Util\Currency()
         );
 
         $notificationModel = new AdyenNotification();

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -362,12 +362,15 @@ class NotificationProcessor
     {
         $cart = \Cart::getCartByOrderId($order->id);
         $cartCurrency = \Currency::getCurrency($cart->id_currency);
+        $orderCurrency = \Currency::getCurrency($order->id_currency);
         $cartCurrencyIso = $cartCurrency['iso_code'];
+        $orderCurrencyIso = $orderCurrency['iso_code'];
 
         $cartTotalMinorUnits = $this->utilCurrency->sanitize($cart->getOrderTotal(), $cartCurrencyIso);
-        $orderTotalMinorUnits = $this->utilCurrency->sanitize($order->getTotalPaid(), $cartCurrencyIso);
+        $orderTotalMinorUnits = $this->utilCurrency->sanitize($order->getTotalPaid(), $orderCurrencyIso);
 
         if ($notification['amount_currency'] !== $cartCurrencyIso ||
+            $notification['amount_currency'] !== $orderCurrencyIso ||
             (int)$notification['amount_value'] !== $cartTotalMinorUnits ||
             (int)$notification['amount_value'] !== $orderTotalMinorUnits) {
             $this->logger->addAdyenNotification(

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -170,11 +170,15 @@ class NotificationProcessor
             case AdyenNotification::AUTHORISATION:
                 if ('true' === $unprocessedNotification['success']) {
                     // If notification data does not match cart and order, set to PAYMENT_NEEDS_ATTENTION
-                    // Else if not in a final status, set to PAYMENT
                     if (!$this->validateWithCartAndOrder($unprocessedNotification, $order)) {
                         $order->setCurrentState(\Configuration::get('ADYEN_OS_PAYMENT_NEEDS_ATTENTION'));
                         $this->orderService->addPaymentDataToOrderFromResponse($order, $unprocessedNotification);
-                    } elseif ($this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
+
+                        return true;
+                    }
+
+                    // If not in a final status, set to PAYMENT
+                    if ($this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
                         $order->setCurrentState(\Configuration::get('PS_OS_PAYMENT'));
 
                         // Add additional data to order if there is any (only possible when the notification success is

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -361,6 +361,11 @@ class NotificationProcessor
     private function validateWithCartAndOrder($notification, OrderCore $order)
     {
         $cart = \Cart::getCartByOrderId($order->id);
+
+        if (!\Validate::isLoadedObject($cart)) {
+            return false;
+        }
+
         $cartCurrency = \Currency::getCurrency($cart->id_currency);
         $orderCurrency = \Currency::getCurrency($order->id_currency);
         $cartCurrencyIso = $cartCurrency['iso_code'];

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -362,6 +362,14 @@ class NotificationProcessor
         $cart = \Cart::getCartByOrderId($order->id);
 
         if (!\Validate::isLoadedObject($cart)) {
+            $this->logger->addAdyenNotification(
+                sprintf(
+                    'Unable to load cart object linked to Order (%s) and Notification (%s)',
+                    $order->id,
+                    $notification['entity_id']
+                )
+            );
+
             return false;
         }
 

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -174,7 +174,7 @@ class NotificationProcessor
                     if (!$this->validateWithCartAndOrder($unprocessedNotification, $order)) {
                         $order->setCurrentState(\Configuration::get('ADYEN_OS_PAYMENT_NEEDS_ATTENTION'));
                         $this->orderService->addPaymentDataToOrderFromResponse($order, $unprocessedNotification);
-                    } else if ($this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
+                    } elseif ($this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
                         $order->setCurrentState(\Configuration::get('PS_OS_PAYMENT'));
 
                         // Add additional data to order if there is any (only possible when the notification success is

--- a/tests/service/Adyen/Service/NotificationProcessorTest.php
+++ b/tests/service/Adyen/Service/NotificationProcessorTest.php
@@ -29,6 +29,7 @@ use Adyen\PrestaShop\model\AdyenPaymentResponse;
 use Adyen\PrestaShop\service\adapter\classes\CustomerThreadAdapter;
 use Adyen\PrestaShop\service\adapter\classes\order\OrderAdapter;
 use Adyen\PrestaShop\service\notification\NotificationProcessor;
+use Adyen\Util\Currency;
 use Context;
 use Db;
 use Mockery as m;
@@ -71,9 +72,14 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
     private $adyenPaymentResponseMock;
 
     /**
-     * @var OrderService|PHPUnit_Framework_MockObject_MockObject orderServiceMock
+     * @var OrderService|PHPUnit_Framework_MockObject_MockObject $orderServiceMock
      */
     private $orderServiceMock;
+
+    /**
+     * @var Currency|PHPUnit_Framework_MockObject_MockObject $utilCurrency
+     */
+    private $utilCurrency;
 
     /**
      *
@@ -115,6 +121,8 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
         $this->orderServiceMock = $this->getMockBuilder(OrderService::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->utilCurrency = new Currency();
     }
 
     protected function tearDown()
@@ -173,7 +181,8 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
             $this->logger,
             $context,
             $this->adyenPaymentResponseMock,
-            $this->orderServiceMock
+            $this->orderServiceMock,
+            $this->utilCurrency
         );
 
         $this->assertTrue($notificationProcessor->addMessage($notification));
@@ -205,7 +214,8 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
             $this->logger,
             $context,
             $this->adyenPaymentResponseMock,
-            $this->orderServiceMock
+            $this->orderServiceMock,
+            $this->utilCurrency
         );
 
         $this->logger->expects($this->once())
@@ -247,7 +257,8 @@ class NotificationProcessorTest extends \PHPUnit_Framework_TestCase
             $this->logger,
             $context,
             $this->adyenPaymentResponseMock,
-            $this->orderServiceMock
+            $this->orderServiceMock,
+            $this->utilCurrency
         );
 
         $this->logger->expects($this->once())


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When processing authorisation w/ `success = true`, verify that the notification amount, order and cart amounts are all equal. If one of these fields does not match, flag it with the `ADYEN_OS_PAYMENT_NEEDS_ATTENTION` status.

## Tested scenarios
* Manually updated notification amount after order was completed
* Manually updated order amount after order was completed
