### PR TITLE
[PW-4033] - Fix translations everywhere in the plugin where it's incorrect 

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1068,7 +1068,8 @@ class AdyenOfficial extends PaymentModule
                 $oneClickOption->setCallToActionText(
                     sprintf(
                         $this->l('Pay by saved %s ending: %s'),
-                        $storedPaymentMethod['name'], $storedPaymentMethod['lastFour']
+                        $storedPaymentMethod['name'],
+                        $storedPaymentMethod['lastFour']
                     )
                 )
                     ->setForm(

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -669,6 +669,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 20,
             'required' => true,
             'lang' => false,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
             'hint' => $this->l('In Adyen backoffice you have a company account with one or more merchantaccounts. Fill in the merchantaccount you want to use for this webshop.')
         );
 
@@ -698,6 +699,7 @@ class AdyenOfficial extends PaymentModule
             'name' => 'ADYEN_NOTI_USERNAME',
             'size' => 20,
             'required' => true,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
             'hint' => $this->l('Must correspond to the notification username in the Adyen Backoffice under Settings => Notifications')
         );
 
@@ -723,6 +725,7 @@ class AdyenOfficial extends PaymentModule
             'class' => $notificationPassword ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
             'hint' => $this->l('Must correspond to the notification password in the Adyen Backoffice under Settings => Notifications')
         );
 
@@ -744,6 +747,7 @@ class AdyenOfficial extends PaymentModule
             'class' => $notificationHmacKey ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
             'hint' => $this->l('Must correspond to the notification HMAC Key in the Adyen Backoffice under Settings => Notifications => Additional Settings => HMAC Key (HEX Encoded)')
         );
 
@@ -764,6 +768,7 @@ class AdyenOfficial extends PaymentModule
         $fields_form[0]['form']['input'][] = array(
             'type' => 'text',
             'desc' => $cronjobToken ?
+                // phpcs:ignore Generic.Files.LineLength.TooLong
                 $this->l('Your adyen cron job processor\'s url includes this secure token. Your URL looks like: ') .
                 sprintf(
                     "%s/%s/index.php?fc=module&controller=AdminAdyenOfficialPrestashopCron&token=%s",
@@ -802,6 +807,7 @@ class AdyenOfficial extends PaymentModule
             'class' => $apiKeyTestLastDigits ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
             'hint' => $this->l('If you don\'t know your Api-Key, log in to your Test Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Checkout token is your API Key.')
         );
 
@@ -828,6 +834,7 @@ class AdyenOfficial extends PaymentModule
             'class' => $apiKeyLiveLastDigits ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
             'hint' => $this->l('If you don\'t know your Api-Key, log in to your Live Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Checkout token is your API Key.')
         );
 
@@ -839,6 +846,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 50,
             'required' => false,
             'lang' => false,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
             'hint' => $this->l('If you don\'t know your client key, log in to your Test Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Client Key is your Client Key.')
         );
 
@@ -850,6 +858,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 50,
             'required' => false,
             'lang' => false,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
             'hint' => $this->l('If you don\'t know your client key, log in to your Live Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Client Key is your Client Key.')
         );
 

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1067,7 +1067,7 @@ class AdyenOfficial extends PaymentModule
                 $oneClickOption = new PrestaShop\PrestaShop\Core\Payment\PaymentOption();
                 $oneClickOption->setCallToActionText(
                     sprintf(
-                        $this->l('Pay by saved %s ending: %s'),
+                        $this->l('Pay by saved') . '%s' . $this->l('ending') . '%s',
                         $storedPaymentMethod['name'],
                         $storedPaymentMethod['lastFour']
                     )

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -669,10 +669,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 20,
             'required' => true,
             'lang' => false,
-            'hint' => $this->l(
-                'In Adyen backoffice you have a company account with one or more merchantaccounts.' .
-                ' Fill in the merchantaccount you want to use for this webshop.'
-            )
+            'hint' => $this->l('In Adyen backoffice you have a company account with one or more merchantaccounts. Fill in the merchantaccount you want to use for this webshop.')
         );
 
         // Test/Production mode
@@ -701,10 +698,7 @@ class AdyenOfficial extends PaymentModule
             'name' => 'ADYEN_NOTI_USERNAME',
             'size' => 20,
             'required' => true,
-            'hint' => $this->l(
-                'Must correspond to the notification username in the Adyen Backoffice under' .
-                ' Settings => Notifications'
-            )
+            'hint' => $this->l('Must correspond to the notification username in the Adyen Backoffice under Settings => Notifications')
         );
 
         $notificationPassword = '';
@@ -729,10 +723,7 @@ class AdyenOfficial extends PaymentModule
             'class' => $notificationPassword ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
-            'hint' => $this->l(
-                'Must correspond to the notification password in the Adyen Backoffice under' .
-                ' Settings => Notifications'
-            )
+            'hint' => $this->l('Must correspond to the notification password in the Adyen Backoffice under Settings => Notifications')
         );
 
         $notificationHmacKey = '';
@@ -753,10 +744,7 @@ class AdyenOfficial extends PaymentModule
             'class' => $notificationHmacKey ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
-            'hint' => $this->l(
-                'Must correspond to the notification HMAC Key in the Adyen Backoffice under' .
-                ' Settings => Notifications => Additional Settings => HMAC Key (HEX Encoded)'
-            )
+            'hint' => $this->l('Must correspond to the notification HMAC Key in the Adyen Backoffice under Settings => Notifications => Additional Settings => HMAC Key (HEX Encoded)')
         );
 
         $cronjobToken = '';
@@ -809,17 +797,12 @@ class AdyenOfficial extends PaymentModule
             'type' => 'password',
             'label' => $this->l('API key for Test'),
             'name' => 'ADYEN_APIKEY_TEST',
-            'desc' => $apiKeyTestLastDigits ? $this->l('Saved key ends in: ') . $apiKeyTestLastDigits : $this->l(
-                'Please fill your API key for Test'
-            ),
+            'desc' => $apiKeyTestLastDigits ? $this->l('Saved key ends in: ') . $apiKeyTestLastDigits :
+                $this->l('Please fill your API key for Test'),
             'class' => $apiKeyTestLastDigits ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
-            'hint' => $this->l(
-                'If you don\'t know your Api-Key, log in to your Test Customer Area. Navigate to' .
-                ' Settings > Users > System, and click on your webservice user, normally this will be' .
-                ' ws@Company.YourCompanyAccount. Under Checkout token is your API Key.'
-            )
+            'hint' => $this->l('If you don\'t know your Api-Key, log in to your Test Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Checkout token is your API Key.')
         );
 
         $apiKeyLive = '';
@@ -840,17 +823,12 @@ class AdyenOfficial extends PaymentModule
             'type' => 'password',
             'label' => $this->l('API key for Live'),
             'name' => 'ADYEN_APIKEY_LIVE',
-            'desc' => $apiKeyLiveLastDigits ? $this->l('Saved key ends in: ') . $apiKeyLiveLastDigits : $this->l(
-                'Please fill your API key for Live'
-            ),
+            'desc' => $apiKeyLiveLastDigits ? $this->l('Saved key ends in: ') . $apiKeyLiveLastDigits :
+                $this->l('Please fill your API key for Live'),
             'class' => $apiKeyLiveLastDigits ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
-            'hint' => $this->l(
-                'If you don\'t know your Api-Key, log in to your Live Customer Area. Navigate to' .
-                ' Settings > Users > System, and click on your webservice user, normally this will be' .
-                ' ws@Company.YourCompanyAccount. Under Checkout token is your API Key.'
-            )
+            'hint' => $this->l('If you don\'t know your Api-Key, log in to your Live Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Checkout token is your API Key.')
         );
 
         // Client key input test
@@ -861,11 +839,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 50,
             'required' => false,
             'lang' => false,
-            'hint' => $this->l(
-                'If you don\'t know your client key, log in to your Test Customer Area. Navigate to' .
-                ' Settings > Users > System, and click on your webservice user, normally this will be' .
-                ' ws@Company.YourCompanyAccount. Under Client Key is your Client Key.'
-            )
+            'hint' => $this->l('If you don\'t know your client key, log in to your Test Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Client Key is your Client Key.')
         );
 
         // Client key input live
@@ -876,11 +850,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 50,
             'required' => false,
             'lang' => false,
-            'hint' => $this->l(
-                'If you don\'t know your client key, log in to your Live Customer Area. Navigate to' .
-                ' Settings > Users > System, and click on your webservice user, normally this will be' .
-                ' ws@Company.YourCompanyAccount. Under Client Key is your Client Key.'
-            )
+            'hint' => $this->l('If you don\'t know your client key, log in to your Live Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Client Key is your Client Key.')
         );
 
         // Live endpoint prefix
@@ -890,9 +860,7 @@ class AdyenOfficial extends PaymentModule
             'name' => 'ADYEN_LIVE_ENDPOINT_URL_PREFIX',
             'size' => 20,
             'required' => false,
-            'hint' => $this->l(
-                'The URL prefix [random]-[company name] from your Adyen live > Account > API URLs.'
-            )
+            'hint' => $this->l('The URL prefix [random]-[company name] from your Adyen live > Account > API URLs.')
         );
 
         $fields_form[1]['form'] = array(
@@ -915,9 +883,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 50,
             'required' => false,
             'lang' => false,
-            'hint' => $this->l(
-                ''
-            )
+            'hint' => $this->l('')
         );
 
         // Apple pay merchant identifier input
@@ -928,9 +894,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 50,
             'required' => false,
             'lang' => false,
-            'hint' => $this->l(
-                ''
-            )
+            'hint' => $this->l('')
         );
 
         // Google pay gateway merchant id
@@ -941,9 +905,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 50,
             'required' => false,
             'lang' => false,
-            'hint' => $this->l(
-                ''
-            )
+            'hint' => $this->l('')
         );
 
         // Google pay merchant identifier input
@@ -954,9 +916,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 50,
             'required' => false,
             'lang' => false,
-            'hint' => $this->l(
-                ''
-            )
+            'hint' => $this->l('')
         );
 
         $fields_form[2]['form'] = array(
@@ -979,9 +939,7 @@ class AdyenOfficial extends PaymentModule
             'size' => 20,
             'required' => false,
             'lang' => false,
-            'hint' => $this->l(
-                'Name of the integrator used. Leave blank if no integrator was utilised.'
-            )
+            'hint' => $this->l('Name of the integrator used. Leave blank if no integrator was utilised.')
         );
 
         $helper = new HelperForm();
@@ -1099,8 +1057,9 @@ class AdyenOfficial extends PaymentModule
 
                 $oneClickOption = new PrestaShop\PrestaShop\Core\Payment\PaymentOption();
                 $oneClickOption->setCallToActionText(
-                    $this->l(
-                        'Pay by saved ' . $storedPaymentMethod['name'] . " ending: " . $storedPaymentMethod['lastFour']
+                    sprintf(
+                        $this->l('Pay by saved %s ending: %s'),
+                        $storedPaymentMethod['name'], $storedPaymentMethod['lastFour']
                     )
                 )
                     ->setForm(

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -776,7 +776,7 @@ class AdyenOfficial extends PaymentModule
         $fields_form[0]['form']['input'][] = array(
             'type' => 'text',
             'desc' => $cronjobToken ?
-                $this->l("Your adyen cron job processor's url includes this secure token . Your URL looks like: ") .
+                $this->l('Your adyen cron job processor\'s url includes this secure token. Your URL looks like: ') .
                 sprintf(
                     "%s/%s/index.php?fc=module&controller=AdminAdyenOfficialPrestashopCron&token=%s",
                     Tools::getShopDomainSsl(),


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

1. Search for ->l( functions in the codebase and check if the translation is used correctly.
3. Fix the usage if incorrect
4. Check if the translation shows up in the admin where the translation can be added

**Invalid translation definition:**
- Any translation containing a variable may [yield unexpected results](https://devdocs.prestashop.com/1.7/modules/creation/module-translation/classic-system/#limitations-and-caveats)
- Any translation [containing a new line](https://github.com/PrestaShop/PrestaShop/issues/11573) between the opening bracket and the first quote will not be translatable
- Any translation containing a double quoted string ie. $this->l("Test string")will not be translatable
