### PR TITLE
[PW-3883] - Prestashop configuration fields are being visually empty after saving 

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -675,14 +675,14 @@ class AdyenOfficial extends PaymentModule
             'type' => 'password',
             'label' => $this->l('Notification Password'),
             'name' => 'ADYEN_NOTI_PASSWORD',
-            'desc' => $notificationPassword ? '' : $this->l('Please fill your notification password'),
+            'desc' => $notificationPassword ? 'Notification password saved' : $this->l('Please fill your notification password'),
             'class' => $notificationPassword ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,
             'hint' => $this->l(
                 'Must correspond to the notification password in the Adyen Backoffice under' .
                 ' Settings => Notifications'
-            )
+            ),
         );
 
         $notificationHmacKey = '';
@@ -699,7 +699,7 @@ class AdyenOfficial extends PaymentModule
             'type' => 'password',
             'label' => $this->l('HMAC key for notifications'),
             'name' => 'ADYEN_NOTI_HMAC',
-            'desc' => $notificationHmacKey ? '' : $this->l('Please fill your notification HMAC key'),
+            'desc' => $notificationHmacKey ? 'HMAC key saved' : $this->l('Please fill your notification HMAC key'),
             'class' => $notificationHmacKey ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -675,7 +675,8 @@ class AdyenOfficial extends PaymentModule
             'type' => 'password',
             'label' => $this->l('Notification Password'),
             'name' => 'ADYEN_NOTI_PASSWORD',
-            'desc' => $notificationPassword ? 'Notification password saved' : $this->l('Please fill your notification password'),
+            'desc' => $notificationPassword ? 'Notification password saved' :
+                $this->l('Please fill your notification password'),
             'class' => $notificationPassword ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -725,7 +725,7 @@ class AdyenOfficial extends PaymentModule
             'type' => 'password',
             'label' => $this->l('Notification Password'),
             'name' => 'ADYEN_NOTI_PASSWORD',
-            'desc' => $notificationPassword ? 'Notification password saved' :
+            'desc' => $notificationPassword ? $this->l('Notification password saved') :
                 $this->l('Please fill your notification password'),
             'class' => $notificationPassword ? 'adyen-input-green' : '',
             'size' => 20,
@@ -750,7 +750,8 @@ class AdyenOfficial extends PaymentModule
             'type' => 'password',
             'label' => $this->l('HMAC key for notifications'),
             'name' => 'ADYEN_NOTI_HMAC',
-            'desc' => $notificationHmacKey ? 'HMAC key saved' : $this->l('Please fill your notification HMAC key'),
+            'desc' => $notificationHmacKey ? $this->l('HMAC key saved') :
+                $this->l('Please fill your notification HMAC key'),
             'class' => $notificationHmacKey ? 'adyen-input-green' : '',
             'size' => 20,
             'required' => false,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
After saving the configuration on Prestashop, some sensitive fields such as HMAC key becomes visually empty and only shows a green outline, which is confusing as green outline feels like it is ready to receive some input. API key has a small reminder underneath the field, yet other fields do not have that and confuses the merchants.

Hence, a **message should be added similar to the (API key one)** to make it clear that the value has been saved. Message should also be translatable.
