### PR TITLE
[PW-2374] -  Do not send shopperReference for guest users in the /paymentMethods request

### DIFF
--- a/helper/Data.php
+++ b/helper/Data.php
@@ -114,7 +114,9 @@ class Data
             );
 
             return array();
-        } elseif (!\Validate::isLoadedObject($customer)) {
+        }
+
+        if (!\Validate::isLoadedObject($customer)) {
             $this->logger->error(
                 sprintf('Unable to load customer linked to Cart (%s)', $cart->id)
             );


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The current prestashop plugin sends the `shopperReference` for both logged in and guest users, since the platform automatically creates a customer for guest users. Hence, we should check if the customer is a guest user and if so, **do not send** the `shopperReference` parameter. Otherwise, this parameter should be normally sent.

## Tested scenarios
- Logged in scenario
- Guest user scenario
