### PR TITLE
[PW-2401] - Return a success message for cronjob after run

### DIFF
--- a/controllers/admin/AdminAdyenOfficialPrestashopCronController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopCronController.php
@@ -99,7 +99,7 @@ class AdminAdyenOfficialPrestashopCronController extends \ModuleAdminController
         } else {
             $message = sprintf(
                 'An error occurred during the execution of the following notifications: %s',
-                implode(',', $failedNotifications)
+                implode(', ', $failedNotifications)
             );
         }
 

--- a/controllers/admin/AdminAdyenOfficialPrestashopCronController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopCronController.php
@@ -111,7 +111,7 @@ class AdminAdyenOfficialPrestashopCronController extends \ModuleAdminController
      */
     public function postProcess()
     {
-        $failedNotifications = [];
+        $failedNotifications = array();
         $notificationProcessor = new NotificationProcessor(
             $this->helperData,
             \Db::getInstance(),

--- a/controllers/admin/AdminAdyenOfficialPrestashopCronController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopCronController.php
@@ -107,7 +107,8 @@ class AdminAdyenOfficialPrestashopCronController extends \ModuleAdminController
     }
 
     /**
-     *
+     * @return array
+     * @throws Exception
      */
     public function postProcess()
     {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When the cron is successfully completed, return some message which enables the merchant to verify and make sure that the it was successfully executed.

Return message: **Cron job finished successfully**

## Tested scenarios

- All notifications successfully processed outputs aforementioned message
- A notification was not successfully processed outputs error message