### PR TITLE
[PW-4115] - Modify how the translate function is called in the FrontController 

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1069,7 +1069,7 @@ class AdyenOfficial extends PaymentModule
                 $oneClickOption = new PrestaShop\PrestaShop\Core\Payment\PaymentOption();
                 $oneClickOption->setCallToActionText(
                     sprintf(
-                        $this->l('Pay by saved') . '%s' . $this->l('ending') . '%s',
+                        $this->l('Pay by saved') . ' %s ' . $this->l('ending') . ': %s',
                         $storedPaymentMethod['name'],
                         $storedPaymentMethod['lastFour']
                     )

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -267,9 +267,9 @@ abstract class FrontController extends \ModuleFrontController
                 $this->logger->error('The payment was ' . strtolower($resultCode) . ', with cart id:  ' . $cart->id);
 
                 if ($resultCode === 'Cancelled') {
-                    $message = $this->l('The payment was cancelled by the customer');
+                    $message = $this->module->l('The payment was cancelled by the customer');
                 } else {
-                    $message = $this->l('The payment was refused');
+                    $message = $this->module->l('The payment was refused');
                 }
 
                 if ($isAjax) {
@@ -377,7 +377,7 @@ abstract class FrontController extends \ModuleFrontController
                 );
 
                 if ($isAjax) {
-                    $message = $this->l('There was an error with the payment method, please choose another one');
+                    $message = $this->module->l('There was an error with the payment method, please choose another one');
                     $this->ajaxRender(
                         $this->helperData->buildControllerResponseJson(
                             'error',
@@ -406,7 +406,7 @@ abstract class FrontController extends \ModuleFrontController
                         $this->helperData->buildControllerResponseJson(
                             'error',
                             array(
-                                'message' => $this->l('Unsupported result code:') . "{" . $response['resultCode'] . "}"
+                                'message' => $this->module->l('Unsupported result code:') . "{" . $response['resultCode'] . "}"
                             )
                         )
                     );

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -264,7 +264,8 @@ abstract class FrontController extends \ModuleFrontController
                 // In case of refused/cancelled payment there is no order created and the cart needs to be cloned and
                 // reinitiated
                 $this->cartService->cloneCurrentCart($this->context, $cart);
-                $this->logger->error('The payment was ' . strtolower($resultCode) . ', with cart id:  ' . $cart->id);
+                $this->logger->error('The payment was ' . \Tools::strtolower($resultCode) . ', with cart id:  ' .
+                    $cart->id);
 
                 if ($resultCode === 'Cancelled') {
                     $message = $this->module->l('The payment was cancelled by the customer');

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -378,6 +378,7 @@ abstract class FrontController extends \ModuleFrontController
                 );
 
                 if ($isAjax) {
+                    // phpcs:ignore Generic.Files.LineLength.TooLong
                     $message = $this->module->l('There was an error with the payment method, please choose another one');
                     $this->ajaxRender(
                         $this->helperData->buildControllerResponseJson(
@@ -407,7 +408,8 @@ abstract class FrontController extends \ModuleFrontController
                         $this->helperData->buildControllerResponseJson(
                             'error',
                             array(
-                                'message' => $this->module->l('Unsupported result code:') . "{" . $response['resultCode'] . "}"
+                                'message' => $this->module->l('Unsupported result code:') .
+                                    "{" . $response['resultCode'] . "}"
                             )
                         )
                     );


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Based on http://doc.prestashop.com/display/PS16/Module+translation on 1.6 we cannot use the ->l() function in the FrontController. Instead $this->module->l() should be used.

## Tested scenarios

- Failed payment, error message correctly shown on 1.7
- Failed payment, error message correctly shown on 1.6
