### PR TITLE
[PW-4153] - Correctly check if shipping_cost should be added to OrderSlip

### DIFF
--- a/service/RefundService.php
+++ b/service/RefundService.php
@@ -25,6 +25,7 @@
 namespace Adyen\PrestaShop\service;
 
 use Adyen\PrestaShop\infra\NotificationRetriever;
+use Adyen\PrestaShop\service\adapter\classes\order\OrderAdapter;
 use Adyen\PrestaShop\service\modification\Refund;
 use Configuration as PrestaShopConfiguration;
 use Currency;
@@ -79,6 +80,7 @@ class RefundService
             $this->modificationService,
             $this->notificationRetriever,
             PrestaShopConfiguration::get('ADYEN_MERCHANT_ACCOUNT'),
+            new OrderAdapter(),
             $this->logger
         );
 

--- a/service/modification/Refund.php
+++ b/service/modification/Refund.php
@@ -96,8 +96,8 @@ class Refund
 
         $fullRefundAmount = $orderSlip->amount;
 
-        // In case shipping cost amount is not empty add shipping costs to the order slip amount
-        if (!empty($orderSlip->shipping_cost)) {
+        // If admin wants to include shipping, add shipping costs to the order slip amount
+        if ($orderSlip->shipping_cost !== '0') {
             $fullRefundAmount += $orderSlip->shipping_cost_amount;
         }
 

--- a/service/modification/Refund.php
+++ b/service/modification/Refund.php
@@ -88,7 +88,7 @@ class Refund
         $fullRefundAmount = $orderSlip->amount;
 
         // In case shipping cost amount is not empty add shipping costs to the order slip amount
-        if (!empty($orderSlip->shipping_cost_amount)) {
+        if (!empty($orderSlip->shipping_cost)) {
             $fullRefundAmount += $orderSlip->shipping_cost_amount;
         }
 

--- a/service/modification/Refund.php
+++ b/service/modification/Refund.php
@@ -97,7 +97,7 @@ class Refund
         $fullRefundAmount = $orderSlip->amount;
 
         // If admin wants to include shipping, add shipping costs to the order slip amount
-        if ($orderSlip->shipping_cost !== '0') {
+        if ($orderSlip->shipping_cost === '1') {
             $fullRefundAmount += $orderSlip->shipping_cost_amount;
         }
 

--- a/tests/modification/RefundTest.php
+++ b/tests/modification/RefundTest.php
@@ -25,6 +25,7 @@
 namespace Adyen\PrestaShop\service\modification;
 
 use Adyen\PrestaShop\infra\NotificationRetriever;
+use Adyen\PrestaShop\service\adapter\classes\order\OrderAdapter;
 use Adyen\Service\Modification;
 use OrderSlip;
 use PHPUnit\Framework\TestCase;
@@ -102,7 +103,13 @@ class RefundTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $refund = new Refund($modificationClient, $notificationRetriever, $merchantAccount, $logger);
+        $refund = new Refund(
+            $modificationClient,
+            $notificationRetriever,
+            $merchantAccount,
+            new OrderAdapter(),
+            $logger
+        );
 
         $this->assertEquals(true, $refund->request($orderSlip, $currency));
     }

--- a/tests/modification/RefundTest.php
+++ b/tests/modification/RefundTest.php
@@ -95,6 +95,7 @@ class RefundTest extends TestCase
                           ->getMock();
         $orderSlip->id_order = $orderId;
         $orderSlip->amount = $amount;
+        $orderSlip->shipping_cost = '0';
         $orderSlip->id = 1;
 
         /** @var PHPUnit_Framework_MockObject_MockObject|NotificationRetriever $notificationRetriever */


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently when an order slip is to be created, if the shipping_amount exists, it is always added to the OrderSlip amount:

```
            if (!empty($orderSlip->shipping_cost_amount)) {
                $fullRefundAmount += $orderSlip->shipping_cost_amount;
            }
```

Hence, instead of checking the amount, the `shipping_cost` flag should be set. This will be set whenever the merchant selects to also refund the shipping amount, from the admin interface.

Also, because of [this issue](https://github.com/Adyen/adyen-prestashop/issues/147) the amount sent to Adyen should be capped, to ensure that the merchant does not attempt to refund a larger amount than the customer actually paid. This issue has [already been identified](https://github.com/PrestaShop/PrestaShop/issues/18319) on prestashop side. This solution should be temporary so a TODO message to remove it once this is fixed, should also be added.

## Tested scenarios

* Refund on order with a discount and no shipping.
  * Exclude amount of initial voucher.
  * Refund amount = specified amount in admin interface = paid amount.
  * Correct credit slip
* Refund on order with a  discount and w/shipping.
  * Exclude amount of initial voucher and repay shipping.
  * Refund amount = specified amount in admin interface + shipping = paid amount.
  * Credit slip has incorrect values (prestashop issue)
* Refund on order with a discount and w/shipping.
  * Exclude amount of initial voucher and do not repay shipping.
  * Refund amount = specified amount in admin interface = paid amount.
  * Correct credit slip
