### PR TITLE
Fix error message in case of missing live url prefix

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -565,7 +565,7 @@ class AdyenOfficial extends PaymentModule
             }
 
             if (empty($live_endpoint_url_prefix)) {
-                $output .= $this->displayError($this->l('Invalid Configuration value for live endpoint url prefix'));
+                $output .= $this->displayError($this->l('Invalid Configuration value for live endpoint URL prefix'));
             }
 
             if ($output == null) {

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -564,6 +564,10 @@ class AdyenOfficial extends PaymentModule
                 $output .= $this->displayError($this->l('Invalid Configuration value for Notification Username'));
             }
 
+            if (empty($live_endpoint_url_prefix)) {
+                $output .= $this->displayError($this->l('Invalid Configuration value for live endpoint url prefix'));
+            }
+
             if ($output == null) {
                 Configuration::updateValue('ADYEN_MERCHANT_ACCOUNT', $merchant_account);
                 Configuration::updateValue('ADYEN_INTEGRATOR_NAME', $integrator_name);
@@ -870,7 +874,7 @@ class AdyenOfficial extends PaymentModule
             'label' => $this->l('Live endpoint prefix'),
             'name' => 'ADYEN_LIVE_ENDPOINT_URL_PREFIX',
             'size' => 20,
-            'required' => false,
+            'required' => true,
             'hint' => $this->l('The URL prefix [random]-[company name] from your Adyen live > Account > API URLs.')
         );
 

--- a/helper/Data.php
+++ b/helper/Data.php
@@ -154,7 +154,7 @@ class Data
         $responseData = "";
         try {
             $responseData = $this->adyenCheckoutService->paymentMethods($adyenFields);
-        } catch (AdyenException $e) {
+        } catch (\Exception $e) {
             $this->logger->error("There was an error retrieving the payment methods. message: " . $e->getMessage());
         }
         return $responseData;


### PR DESCRIPTION
## Summary
In case the mode is production and the live url prefix is empty the module shows an exception which is thrown by the library. In order to avoid this certain scenario the live url prefix is required from now on.
In case an (network or other non Adyen related) error shows up during the payment methods request we catch all these to avoid showing it on the frontend and instead we just log it in the error.log file in the adyen folder.