### PR TITLE
[PW-3071] - How to implement a nicer error page than the current in 1.7

### DIFF
--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -283,8 +283,13 @@ abstract class FrontController extends \ModuleFrontController
                         )
                     );
                 } else {
-                    $this->setTemplate(
-                        $this->helperData->getTemplateFromModulePath('views/templates/front/error.tpl')
+
+                    $this->redirectUserToPageLink(
+                        $this->context->link->getPageLink(
+                            'order',
+                            $this->ssl
+                        ),
+                        $isAjax
                     );
                 }
 

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -283,16 +283,21 @@ abstract class FrontController extends \ModuleFrontController
                         )
                     );
                 } else {
-
-                    $this->redirectUserToPageLink(
-                        $this->context->link->getPageLink(
-                            'order',
-                            $this->ssl,
-                            null,
-                            sprintf('message=%s', $message)
-                        ),
-                        $isAjax
-                    );
+                    if ($this->versionChecker->isPrestaShop16()) {
+                        $this->setTemplate(
+                            $this->helperData->getTemplateFromModulePath('views/templates/front/error.tpl')
+                        );
+                    } else {
+                        $this->redirectUserToPageLink(
+                            $this->context->link->getPageLink(
+                                'order',
+                                $this->ssl,
+                                null,
+                                sprintf('message=%s', $message)
+                            ),
+                            $isAjax
+                        );
+                    }
                 }
 
                 break;

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -287,7 +287,9 @@ abstract class FrontController extends \ModuleFrontController
                     $this->redirectUserToPageLink(
                         $this->context->link->getPageLink(
                             'order',
-                            $this->ssl
+                            $this->ssl,
+                            null,
+                            sprintf('message=%s', $message)
                         ),
                         $isAjax
                     );

--- a/service/Cart.php
+++ b/service/Cart.php
@@ -49,6 +49,7 @@ class Cart
         $context->cart->secure_key = $old_cart_secure_key;
         // to add new cart
         $context->cart->add();
+        $newCartId  = $context->cart->id;
         // to update the new cart
         foreach ($cart_products as $product) {
             $context->cart->updateQty(
@@ -62,13 +63,15 @@ class Cart
             $context->cart->mobile_theme = $guest->mobile_theme;
         }
 
+        // Get the checkout_session_data field of the previous cart
         $checkoutSessionData = \Db::getInstance()->getValue(
             'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int) $cart->id
         );
 
+        // Update the checkout_session_data field of the new cart
         \Db::getInstance()->execute(
             'UPDATE ' . _DB_PREFIX_ . 'cart SET checkout_session_data = "' . pSQL($checkoutSessionData) . '"
-        WHERE id_cart = ' . (int) $context->cart->id
+        WHERE id_cart = ' . (int) $newCartId
         );
 
         // to map the new cart with the customer

--- a/service/Cart.php
+++ b/service/Cart.php
@@ -61,6 +61,16 @@ class Cart
             $guest = new \Guest($context->cookie->id_guest);
             $context->cart->mobile_theme = $guest->mobile_theme;
         }
+
+        $checkoutSessionData = \Db::getInstance()->getValue(
+            'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int) $cart->id
+        );
+
+        \Db::getInstance()->execute(
+            'UPDATE ' . _DB_PREFIX_ . 'cart SET checkout_session_data = "' . pSQL($checkoutSessionData) . '"
+        WHERE id_cart = ' . (int) $context->cart->id
+        );
+
         // to map the new cart with the customer
         $context->cart->id_customer = $old_cart_customer_id;
         // to save the new cart

--- a/service/Cart.php
+++ b/service/Cart.php
@@ -73,6 +73,7 @@ class Cart
 
         // to map the new cart with the customer
         $context->cart->id_customer = $old_cart_customer_id;
+        $context->cart->id_guest = $cart->id_guest;
         // to save the new cart
         $context->cart->save();
         if ($context->cart->id) {

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -76,7 +76,11 @@ jQuery(document).ready(function() {
             // observer exception
         }
     } else {
-        showRedirectErrorMessage();
+        const queryParams = new URLSearchParams(window.location.search);
+        if (queryParams.has('message')) {
+            showRedirectErrorMessage(queryParams.get('message'));
+        }
+
         $('input[name="payment-option"]').on('change', function(event) {
 
             let selectedPaymentForm = $(
@@ -104,13 +108,10 @@ jQuery(document).ready(function() {
         });
     }
 
-    function showRedirectErrorMessage() {
-        const queryParams = new URLSearchParams(window.location.search);
-        if (queryParams.has('message')) {
-            const errorDiv = $('<div class="alert alert-danger error-container" role="alert"></div>');
-            errorDiv.text(queryParams.get('message'));
-            $('.payment-options').append(errorDiv);
-        }
+    function showRedirectErrorMessage(message) {
+        const errorDiv = $('<div class="alert alert-danger error-container" role="alert"></div>');
+        errorDiv.text(message);
+        $('.payment-options').append(errorDiv);
     }
 
     function renderPaymentMethods() {

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -76,6 +76,7 @@ jQuery(document).ready(function() {
             // observer exception
         }
     } else {
+        showRedirectErrorMessage();
         $('input[name="payment-option"]').on('change', function(event) {
 
             let selectedPaymentForm = $(
@@ -101,6 +102,15 @@ jQuery(document).ready(function() {
                 }
             }
         });
+    }
+
+    function showRedirectErrorMessage() {
+        const queryParams = new URLSearchParams(window.location.search);
+        if (queryParams.has('message')) {
+            const errorDiv = $('<div class="alert alert-danger error-container" role="alert"></div>');
+            errorDiv.text(queryParams.get('message'));
+            $('.payment-options').append(errorDiv);
+        }
     }
 
     function renderPaymentMethods() {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In 1.7 when the customer has an error during the redirection, they are sent back to a blank error page. Instead, we should redirect them back to the payment methods page and show an error message.

## Tested scenarios
* Happy flow on 1.6, 1.7
* Error during redirection on 1.7 which displays the previously mentioned message
* Error during redirection on 1.6
