### PR TITLE
[PW 2778] - Display the payment methods as the default payment methods 

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -466,7 +466,8 @@ class AdyenOfficial extends PaymentModule
             'ADYEN_APPLE_PAY_MERCHANT_NAME',
             'ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER',
             'ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID',
-            'ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER'
+            'ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER',
+            'ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE'
         );
 
         $result = true;
@@ -550,6 +551,8 @@ class AdyenOfficial extends PaymentModule
             $apple_pay_merchant_identifier = Tools::getValue('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER');
             $google_pay_gateway_merchant_id = Tools::getValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
+            $remove_payment_display_collapse = Tools::getValue('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE');
+
 
             // validating the input
             if (empty($merchant_account) || !Validate::isGenericName($merchant_account)) {
@@ -588,6 +591,7 @@ class AdyenOfficial extends PaymentModule
                 Configuration::updateValue('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER', $apple_pay_merchant_identifier);
                 Configuration::updateValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID', $google_pay_gateway_merchant_id);
                 Configuration::updateValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER', $google_pay_merchant_identifier);
+                Configuration::updateValue('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE', $remove_payment_display_collapse);
 
                 if (!empty($notification_password)) {
                     Configuration::updateValue('ADYEN_NOTI_PASSWORD', $this->crypto->encrypt($notification_password));
@@ -944,6 +948,31 @@ class AdyenOfficial extends PaymentModule
             'hint' => $this->l('')
         );
 
+        if ($this->versionChecker->isPrestaShop16()) {
+            $fields_form[1]['form']['input'][] = array(
+                'type' => 'radio',
+                'label' => $this->l('Remove collapsable payment display'),
+                'name' => 'ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE',
+                'values' => array(
+                    array(
+                        'id' => 'enable',
+                        'value' => 1,
+                        'label' => $this->l('Yes')
+                    ),
+                    array(
+                        'id' => 'disable',
+                        'value' => 0,
+                        'label' => $this->l('No')
+                    )
+                ),
+                'is_bool' => true,
+                // phpcs:ignore Generic.Files.LineLength.TooLong
+                'hint' => 'Indicates whether the payment methods should be rendered in a list of collapsable items,
+                 during checkout',
+                'required' => true
+            );
+        }
+
         $fields_form[2]['form'] = array(
             'legend' => array(
                 'title' => $this->l('Developer settings'),
@@ -1015,6 +1044,7 @@ class AdyenOfficial extends PaymentModule
             $apple_pay_merchant_identifier = Tools::getValue('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER');
             $google_pay_gateway_merchant_id = Tools::getValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
+            $remove_payment_display_collapse = Tools::getValue('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE');
         } else {
             $merchant_account = Configuration::get('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = Configuration::get('ADYEN_INTEGRATOR_NAME');
@@ -1029,6 +1059,7 @@ class AdyenOfficial extends PaymentModule
             $apple_pay_merchant_identifier = Configuration::get('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER');
             $google_pay_gateway_merchant_id = Configuration::get('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Configuration::get('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
+            $remove_payment_display_collapse = Tools::getValue('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE');
         }
 
         // Load current value
@@ -1044,6 +1075,7 @@ class AdyenOfficial extends PaymentModule
         $helper->fields_value['ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER'] = $apple_pay_merchant_identifier;
         $helper->fields_value['ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID'] = $google_pay_gateway_merchant_id;
         $helper->fields_value['ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER'] = $google_pay_merchant_identifier;
+        $helper->fields_value['ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE'] = $remove_payment_display_collapse;
 
         return $helper->generateForm($fields_form);
     }
@@ -1530,7 +1562,8 @@ class AdyenOfficial extends PaymentModule
                     'storedPaymentApiId' => $storedPayment['id'],
                     'name' => $storedPayment['name'],
                     'logoBrand' => $storedPayment['brand'],
-                    'number' => $storedPayment['lastFour']
+                    'number' => $storedPayment['lastFour'],
+                    'removeCollapse' => \Configuration::get('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE')
                 );
 
                 // Add checkout component default configuration parameters for smarty variables
@@ -1560,7 +1593,8 @@ class AdyenOfficial extends PaymentModule
             $smartyVariables = array(
                 'paymentMethodType' => $paymentMethod['type'],
                 'paymentMethodName' => $paymentMethod['name'],
-                'paymentMethodBrand' => $paymentMethod['type']
+                'paymentMethodBrand' => $paymentMethod['type'],
+                'removeCollapse' => \Configuration::get('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE')
             );
 
             // If brand is scheme, logo will not be displayed correctly unless it is set to card

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1529,6 +1529,7 @@ class AdyenOfficial extends PaymentModule
                 $smartyVariables = array(
                     'storedPaymentApiId' => $storedPayment['id'],
                     'name' => $storedPayment['name'],
+                    'brand' => $storedPayment['brand'],
                     'number' => $storedPayment['lastFour']
                 );
 
@@ -1558,8 +1559,14 @@ class AdyenOfficial extends PaymentModule
 
             $smartyVariables = array(
                 'paymentMethodType' => $paymentMethod['type'],
-                'paymentMethodName' => $paymentMethod['name']
+                'paymentMethodName' => $paymentMethod['name'],
+                'paymentMethodBrand' => $paymentMethod['type']
             );
+
+            // If brand is scheme, logo will not be displayed correctly unless it is set to card
+            if ($paymentMethod['type'] === 'scheme') {
+                $smartyVariables['paymentMethodBrand'] = 'card';
+            }
 
             // Add checkout component default configuration parameters for smarty variables
             $smartyVariables = array_merge($smartyVariables, $this->getCheckoutComponentInitData());

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -969,7 +969,7 @@ class AdyenOfficial extends PaymentModule
                 // phpcs:ignore Generic.Files.LineLength.TooLong
                 'hint' => 'Indicates whether the payment methods should be rendered in a list of collapsable items,
                  during checkout',
-                'required' => true
+                'required' => false
             );
         }
 

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1529,7 +1529,7 @@ class AdyenOfficial extends PaymentModule
                 $smartyVariables = array(
                     'storedPaymentApiId' => $storedPayment['id'],
                     'name' => $storedPayment['name'],
-                    'brand' => $storedPayment['brand'],
+                    'logoBrand' => $storedPayment['brand'],
                     'number' => $storedPayment['lastFour']
                 );
 

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -467,7 +467,7 @@ class AdyenOfficial extends PaymentModule
             'ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER',
             'ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID',
             'ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER',
-            'ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE'
+            'ADYEN_PAYMENT_DISPLAY_COLLAPSE'
         );
 
         $result = true;
@@ -551,7 +551,7 @@ class AdyenOfficial extends PaymentModule
             $apple_pay_merchant_identifier = Tools::getValue('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER');
             $google_pay_gateway_merchant_id = Tools::getValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
-            $remove_payment_display_collapse = Tools::getValue('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE');
+            $payment_display_collapse = Tools::getValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
 
 
             // validating the input
@@ -591,7 +591,7 @@ class AdyenOfficial extends PaymentModule
                 Configuration::updateValue('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER', $apple_pay_merchant_identifier);
                 Configuration::updateValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID', $google_pay_gateway_merchant_id);
                 Configuration::updateValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER', $google_pay_merchant_identifier);
-                Configuration::updateValue('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE', $remove_payment_display_collapse);
+                Configuration::updateValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE', $payment_display_collapse);
 
                 if (!empty($notification_password)) {
                     Configuration::updateValue('ADYEN_NOTI_PASSWORD', $this->crypto->encrypt($notification_password));
@@ -951,18 +951,18 @@ class AdyenOfficial extends PaymentModule
         if ($this->versionChecker->isPrestaShop16()) {
             $fields_form[1]['form']['input'][] = array(
                 'type' => 'radio',
-                'label' => $this->l('Remove collapsable payment display'),
-                'name' => 'ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE',
+                'label' => $this->l('Collapsable payment display'),
+                'name' => 'ADYEN_PAYMENT_DISPLAY_COLLAPSE',
                 'values' => array(
                     array(
                         'id' => 'enable',
                         'value' => 1,
-                        'label' => $this->l('Yes')
+                        'label' => $this->l('Enable')
                     ),
                     array(
                         'id' => 'disable',
                         'value' => 0,
-                        'label' => $this->l('No')
+                        'label' => $this->l('Disable')
                     )
                 ),
                 'is_bool' => true,
@@ -1044,7 +1044,7 @@ class AdyenOfficial extends PaymentModule
             $apple_pay_merchant_identifier = Tools::getValue('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER');
             $google_pay_gateway_merchant_id = Tools::getValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
-            $remove_payment_display_collapse = Tools::getValue('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE');
+            $payment_display_collapse = Tools::getValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
         } else {
             $merchant_account = Configuration::get('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = Configuration::get('ADYEN_INTEGRATOR_NAME');
@@ -1059,7 +1059,7 @@ class AdyenOfficial extends PaymentModule
             $apple_pay_merchant_identifier = Configuration::get('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER');
             $google_pay_gateway_merchant_id = Configuration::get('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Configuration::get('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
-            $remove_payment_display_collapse = Tools::getValue('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE');
+            $payment_display_collapse = Tools::getValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
         }
 
         // Load current value
@@ -1075,7 +1075,7 @@ class AdyenOfficial extends PaymentModule
         $helper->fields_value['ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER'] = $apple_pay_merchant_identifier;
         $helper->fields_value['ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID'] = $google_pay_gateway_merchant_id;
         $helper->fields_value['ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER'] = $google_pay_merchant_identifier;
-        $helper->fields_value['ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE'] = $remove_payment_display_collapse;
+        $helper->fields_value['ADYEN_PAYMENT_DISPLAY_COLLAPSE'] = $payment_display_collapse;
 
         return $helper->generateForm($fields_form);
     }
@@ -1558,12 +1558,14 @@ class AdyenOfficial extends PaymentModule
                     continue;
                 }
 
+                $collapsePayments = \Configuration::get('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
+
                 $smartyVariables = array(
                     'storedPaymentApiId' => $storedPayment['id'],
                     'name' => $storedPayment['name'],
                     'logoBrand' => $storedPayment['brand'],
                     'number' => $storedPayment['lastFour'],
-                    'removeCollapse' => \Configuration::get('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE')
+                    'collapsePayments' => $collapsePayments === false ? '0' : $collapsePayments
                 );
 
                 // Add checkout component default configuration parameters for smarty variables
@@ -1590,11 +1592,13 @@ class AdyenOfficial extends PaymentModule
                 continue;
             }
 
+            $collapsePayments = \Configuration::get('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
+
             $smartyVariables = array(
                 'paymentMethodType' => $paymentMethod['type'],
                 'paymentMethodName' => $paymentMethod['name'],
                 'paymentMethodBrand' => $paymentMethod['type'],
-                'removeCollapse' => \Configuration::get('ADYEN_REMOVE_PAYMENT_DISPLAY_COLLAPSE')
+                'collapsePayments' => $collapsePayments === false ? '0' : $collapsePayments
             );
 
             // If brand is scheme, logo will not be displayed correctly unless it is set to card

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -90,6 +90,10 @@ div.adyen-additional-data-line {
     }
 }
 
+.adyen-payment .additional-information.mb-0 {
+    margin-bottom: 0;
+}
+
 .adyen-payment .additional-information {
     margin-bottom: 1rem;
 }
@@ -104,7 +108,7 @@ body#checkout section.checkout-step .payment-options label {
     margin-bottom: 0;
 }
 
-#HOOK_PAYMENT .adyen-payment .payment_module {
+.adyen-payment .payment_module.adyen-collapser {
     border: 1px solid #d6d4d4;
     margin-bottom: 9px;
     padding: 33px 40px 34px 99px;
@@ -112,16 +116,27 @@ body#checkout section.checkout-step .payment-options label {
     background-repeat: no-repeat;
     background-position-y: 25px;
     background-position-x: 15px;
-}
-
-#HOOK_PAYMENT .collapser {
     cursor: pointer;
 }
 
-#HOOK_PAYMENT .collapser:hover {
+.adyen-collapser:hover {
     background-color: #f6f6f6;
 }
 
-#HOOK_PAYMENT .adyen-payment .additional-information {
-    margin-bottom: 0;
+.adyen-payment .payment_module.adyen-collapser:after {
+    display: block;
+    content: "\f077";
+    position: absolute;
+    right: 40px;
+    margin-top: -11px;
+    top: 30px;
+    font-family: "FontAwesome";
+    font-size: 25px;
+    height: 22px;
+    width: 14px;
+    color: #777;
+}
+
+.adyen-payment .payment_module.adyen-collapser.collapsed:after {
+    content: "\f078";
 }

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -29,15 +29,6 @@
     margin-top: -13px;
 }
 
-.payment_module input {
-    border: 0;
-    background: none;
-}
-
-.payment_module input:hover {
-    text-decoration: underline;
-}
-
 ul.adyen-hpp-options {
     list-style-type: none;
     margin-left: 10px;

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -119,7 +119,7 @@ body#checkout section.checkout-step .payment-options label {
     cursor: pointer;
 }
 
-.adyen-collapser:hover {
+.adyen-payment .payment_module.adyen-collapser:hover {
     background-color: #f6f6f6;
 }
 

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -74,7 +74,7 @@ div.adyen-payment .error-container, div.adyen-payment .info-container {
     display: none;
 }
 
-div.adyen-payment-method-label {
+div.adyen-payment-method-label, span.adyen-payment-method-label {
     display: inline-block;
     margin: 6px 0;
     font-size: 16px;
@@ -101,5 +101,24 @@ div.adyen-additional-data-line {
 
 body#checkout section.checkout-step .payment-options label {
     display: inline-block;
+    margin-bottom: 0;
+}
+
+#HOOK_PAYMENT .adyen-payment .payment_module {
+    border: 1px solid #d6d4d4;
+    margin-bottom: 9px;
+    padding: 33px 40px 34px 99px;
+    background: #fbfbfb;
+}
+
+#HOOK_PAYMENT .collapser {
+    cursor: pointer;
+}
+
+#HOOK_PAYMENT .collapser:hover {
+    background: #f6f6f6;
+}
+
+#HOOK_PAYMENT .adyen-payment .additional-information {
     margin-bottom: 0;
 }

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -108,7 +108,7 @@ body#checkout section.checkout-step .payment-options label {
     margin-bottom: 0;
 }
 
-.adyen-payment .payment_module.adyen-collapser {
+.adyen-payment .payment_module {
     border: 1px solid #d6d4d4;
     margin-bottom: 9px;
     padding: 33px 40px 34px 99px;
@@ -116,14 +116,13 @@ body#checkout section.checkout-step .payment-options label {
     background-repeat: no-repeat;
     background-position-y: 25px;
     background-position-x: 15px;
-    cursor: pointer;
 }
 
-.adyen-payment .payment_module.adyen-collapser:hover {
+.adyen-payment .payment_module:hover {
     background-color: #f6f6f6;
 }
 
-.adyen-payment .payment_module.adyen-collapser:after {
+.adyen-payment .adyen-collapser:after {
     display: block;
     content: "\f077";
     position: absolute;
@@ -137,6 +136,10 @@ body#checkout section.checkout-step .payment-options label {
     color: #777;
 }
 
-.adyen-payment .payment_module.adyen-collapser.collapsed:after {
+.adyen-payment .adyen-collapser.collapsed:after {
     content: "\f078";
+}
+
+.adyen-payment .adyen-collapser.adyen-payment-method-label {
+    cursor: pointer;
 }

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -108,7 +108,10 @@ body#checkout section.checkout-step .payment-options label {
     border: 1px solid #d6d4d4;
     margin-bottom: 9px;
     padding: 33px 40px 34px 99px;
-    background: #fbfbfb;
+    background-color: #fbfbfb;
+    background-repeat: no-repeat;
+    background-position-y: 25px;
+    background-position-x: 15px;
 }
 
 #HOOK_PAYMENT .collapser {
@@ -116,7 +119,7 @@ body#checkout section.checkout-step .payment-options label {
 }
 
 #HOOK_PAYMENT .collapser:hover {
-    background: #f6f6f6;
+    background-color: #f6f6f6;
 }
 
 #HOOK_PAYMENT .adyen-payment .additional-information {

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -93,3 +93,13 @@ div.adyen-additional-data-line {
 .adyen-payment .additional-information {
     margin-bottom: 1rem;
 }
+
+.custom-radio.float-xs-left {
+    float: none !important;
+    display: inline-block;
+}
+
+body#checkout section.checkout-step .payment-options label {
+    display: inline-block;
+    margin-bottom: 0;
+}

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -89,3 +89,7 @@ div.adyen-additional-data-line {
         -webkit-appearance: -apple-pay-button;
     }
 }
+
+.adyen-payment .additional-information {
+    margin-bottom: 1rem;
+}

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -75,8 +75,6 @@ jQuery(document).ready(function() {
         } catch (e) {
             // observer exception
         }
-
-        stopPaymentMethodDivCollapse();
     } else {
         const queryParams = new URLSearchParams(window.location.search);
         if (queryParams.has('message')) {
@@ -635,13 +633,5 @@ jQuery(document).ready(function() {
 
     function isPlaceOrderInProgress() {
         return placeOrderInProgress;
-    }
-
-    // When these buttons are clicked, do not close the payment method div
-    function stopPaymentMethodDivCollapse() {
-        $('body').on('click', '.adyen-collapsable button, .adyen-collapsable input, .adyen-collapsable' +
-            ' ul, .adyen-collapsable .error-container, .adyen-collapsable .adyen-checkout__checkbox', function (e) {
-            e.stopPropagation();
-        });
     }
 });

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -76,9 +76,7 @@ jQuery(document).ready(function() {
             // observer exception
         }
 
-        $('.adyen-payment .standard-checkout, .adyen-payment .error-container').on('click', function (e) {
-            e.stopPropagation();
-        });
+        stopPayButtonCollapse();
     } else {
         const queryParams = new URLSearchParams(window.location.search);
         if (queryParams.has('message')) {
@@ -637,5 +635,11 @@ jQuery(document).ready(function() {
 
     function isPlaceOrderInProgress() {
         return placeOrderInProgress;
+    }
+
+    function stopPayButtonCollapse() {
+        $('.adyen-payment .standard-checkout, .adyen-payment .error-container').on('click', function (e) {
+            e.stopPropagation();
+        });
     }
 });

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -75,6 +75,10 @@ jQuery(document).ready(function() {
         } catch (e) {
             // observer exception
         }
+
+        $('.adyen-payment .standard-checkout, .adyen-payment .error-container').on('click', function (e) {
+            e.stopPropagation();
+        });
     } else {
         const queryParams = new URLSearchParams(window.location.search);
         if (queryParams.has('message')) {

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -76,7 +76,7 @@ jQuery(document).ready(function() {
             // observer exception
         }
 
-        stopPayButtonCollapse();
+        stopPaymentMethodDivCollapse();
     } else {
         const queryParams = new URLSearchParams(window.location.search);
         if (queryParams.has('message')) {
@@ -637,8 +637,10 @@ jQuery(document).ready(function() {
         return placeOrderInProgress;
     }
 
-    function stopPayButtonCollapse() {
-        $('.adyen-payment .standard-checkout, .adyen-payment .error-container').on('click', function (e) {
+    // When these buttons are clicked, do not close the payment method div
+    function stopPaymentMethodDivCollapse() {
+        $('body').on('click', '.adyen-collapsable button, .adyen-collapsable input, .adyen-collapsable' +
+            ' .error-container, .adyen-collapsable .adyen-checkout__checkbox', function (e) {
             e.stopPropagation();
         });
     }

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -640,7 +640,7 @@ jQuery(document).ready(function() {
     // When these buttons are clicked, do not close the payment method div
     function stopPaymentMethodDivCollapse() {
         $('body').on('click', '.adyen-collapsable button, .adyen-collapsable input, .adyen-collapsable' +
-            ' .error-container, .adyen-collapsable .adyen-checkout__checkbox', function (e) {
+            ' ul, .adyen-collapsable .error-container, .adyen-collapsable .adyen-checkout__checkbox', function (e) {
             e.stopPropagation();
         });
     }

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -42,7 +42,7 @@
                         <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                               class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'} additional-information" method="post">
                             {* Collapsable section *}
-                            <div id="collapse{$paymentMethodType|escape:'html':'UTF-8'}" class="collapse">
+                            <div id="collapse{$paymentMethodType|escape:'html':'UTF-8'}" class="adyen-collapsable collapse">
                                 <div data-adyen-payment-container></div>
                                 {* Display payment extra info *}
                                 <div class="alert alert-info info-container" role="alert"></div>

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -32,10 +32,7 @@
             <div class="payment_module">
                 <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                       class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'}" method="post">
-                    <div class="adyen-payment-method-label">
-                        {l s='Pay with %s' sprintf=[{$paymentMethodName|escape:'html':'UTF-8'}] mod='adyenofficial'}
-                    </div>
-                    <div data-adyen-payment-container></div>
+                    <div data-adyen-payment-container class="additional-information"></div>
                     <!-- Display payment extra info -->
                     <div class="alert alert-info info-container" role="alert"></div>
                     <!-- Display payment errors -->

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -30,7 +30,7 @@
          data-local-payment-method="{$paymentMethodType|escape:'html':'UTF-8'}">
         {if $isPrestaShop16}
         <div class="col-xs-12 col-md-12">
-            <div class="payment_module collapser" data-toggle="collapse"
+            <div class="payment_module adyen-collapser collapsed" data-toggle="collapse"
                  data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="true" aria-controls="collapseOne"
                  style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$paymentMethodBrand|escape:'html':'UTF-8'}.png)">
                 <span class="adyen-payment-method-label">

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -35,7 +35,7 @@
                  aria-controls="collapse{$paymentMethodType|escape:'html':'UTF-8'}"
                  style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$paymentMethodBrand|escape:'html':'UTF-8'}.png)">
                 <span class="adyen-payment-method-label">
-                    {l s='Pay with %s' sprintf=[{$paymentMethodName|escape:'html':'UTF-8'}] mod='adyenofficial'}
+                    {l s='Pay by %s' sprintf=[{$paymentMethodName|escape:'html':'UTF-8'}] mod='adyenofficial'}
                 </span>
                 <div class="row">
                     <div class="col-xs-12 col-md-6">

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -41,11 +41,12 @@
                     <div class="col-xs-12 col-md-6">
                         <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                               class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'} additional-information" method="post">
+                            {* Collapsable section *}
                             <div id="collapse{$paymentMethodType|escape:'html':'UTF-8'}" class="collapse">
                                 <div data-adyen-payment-container></div>
-                                <!-- Display payment extra info -->
+                                {* Display payment extra info *}
                                 <div class="alert alert-info info-container" role="alert"></div>
-                                <!-- Display payment errors -->
+                                {* Display payment errors *}
                                 <div class="alert alert-danger error-container" role="alert"></div>
                                 <div data-adyen-payment-error-container role="alert"></div>
                                 {if !in_array($paymentMethodType, $paymentMethodsWithPayButtonFromComponent|json_decode:1)}
@@ -65,9 +66,9 @@
                 <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                       class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'} additional-information" method="post">
                     <div data-adyen-payment-container></div>
-                    <!-- Display payment extra info -->
+                    {* Display payment extra info *}
                     <div class="alert alert-info info-container" role="alert"></div>
-                    <!-- Display payment errors -->
+                    {* Display payment errors *}
                     <div class="alert alert-danger error-container" role="alert"></div>
                     <div data-adyen-payment-error-container role="alert"></div>
                 </form>

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -30,11 +30,10 @@
          data-local-payment-method="{$paymentMethodType|escape:'html':'UTF-8'}">
         {if $isPrestaShop16}
         <div class="col-xs-12 col-md-12">
-            <div class="payment_module adyen-collapser collapsed" data-toggle="collapse"
-                 data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="false"
-                 aria-controls="collapse{$paymentMethodType|escape:'html':'UTF-8'}"
-                 style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$paymentMethodBrand|escape:'html':'UTF-8'}.png)">
-                <span class="adyen-payment-method-label">
+            <div class="payment_module" style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$paymentMethodBrand|escape:'html':'UTF-8'}.png)">
+                <span class="adyen-payment-method-label adyen-collapser collapsed" data-toggle="collapse"
+                      data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="false"
+                      aria-controls="collapse{$paymentMethodType|escape:'html':'UTF-8'}">
                     {l s='Pay by %s' sprintf=[{$paymentMethodName|escape:'html':'UTF-8'}] mod='adyenofficial'}
                 </span>
                 <div class="row">

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -31,8 +31,8 @@
         {if $isPrestaShop16}
         <div class="col-xs-12 col-md-12">
             <div class="payment_module" style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$paymentMethodBrand|escape:'html':'UTF-8'}.png)">
-                {* If collapsing is NOT disabled due to config *}
-                <span {if empty($removeCollapse)} class="adyen-payment-method-label adyen-collapser collapsed" data-toggle="collapse" data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="false" aria-controls="collapse{$paymentMethodType|escape:'html':'UTF-8'}"
+                {* If collapsing is enabled by config *}
+                <span {if $collapsePayments} class="adyen-payment-method-label adyen-collapser collapsed" data-toggle="collapse" data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="false" aria-controls="collapse{$paymentMethodType|escape:'html':'UTF-8'}"
                         {else} class="adyen-payment-method-label" {/if}>
                     {l s='Pay by %s' sprintf=[{$paymentMethodName|escape:'html':'UTF-8'}] mod='adyenofficial'}
                 </span>
@@ -40,8 +40,8 @@
                     <div class="col-xs-12 col-md-6">
                         <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                               class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'} additional-information" method="post">
-                            {* If collapsing is NOT disabled due to config *}
-                            <div {if empty($removeCollapse)} id="collapse{$paymentMethodType|escape:'html':'UTF-8'}" class="adyen-collapsable collapse" {/if}>
+                            {* If collapsing is enabled by config *}
+                            <div {if $collapsePayments} id="collapse{$paymentMethodType|escape:'html':'UTF-8'}" class="adyen-collapsable collapse" {/if}>
                                 <div data-adyen-payment-container></div>
                                 {* Display payment extra info *}
                                 <div class="alert alert-info info-container" role="alert"></div>

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -31,7 +31,8 @@
         {if $isPrestaShop16}
         <div class="col-xs-12 col-md-12">
             <div class="payment_module adyen-collapser collapsed" data-toggle="collapse"
-                 data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="true" aria-controls="collapseOne"
+                 data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="false"
+                 aria-controls="collapse{$paymentMethodType|escape:'html':'UTF-8'}"
                  style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$paymentMethodBrand|escape:'html':'UTF-8'}.png)">
                 <span class="adyen-payment-method-label">
                     {l s='Pay with %s' sprintf=[{$paymentMethodName|escape:'html':'UTF-8'}] mod='adyenofficial'}

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -31,8 +31,8 @@
         <div class="col-xs-12 col-md-6">
             <div class="payment_module">
                 <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
-                      class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'}" method="post">
-                    <div data-adyen-payment-container class="additional-information"></div>
+                      class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'} additional-information" method="post">
+                    <div data-adyen-payment-container></div>
                     <!-- Display payment extra info -->
                     <div class="alert alert-info info-container" role="alert"></div>
                     <!-- Display payment errors -->

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -31,17 +31,17 @@
         {if $isPrestaShop16}
         <div class="col-xs-12 col-md-12">
             <div class="payment_module" style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$paymentMethodBrand|escape:'html':'UTF-8'}.png)">
-                <span class="adyen-payment-method-label adyen-collapser collapsed" data-toggle="collapse"
-                      data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="false"
-                      aria-controls="collapse{$paymentMethodType|escape:'html':'UTF-8'}">
+                {* If collapsing is NOT disabled due to config *}
+                <span {if empty($removeCollapse)} class="adyen-payment-method-label adyen-collapser collapsed" data-toggle="collapse" data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="false" aria-controls="collapse{$paymentMethodType|escape:'html':'UTF-8'}"
+                        {else} class="adyen-payment-method-label" {/if}>
                     {l s='Pay by %s' sprintf=[{$paymentMethodName|escape:'html':'UTF-8'}] mod='adyenofficial'}
                 </span>
                 <div class="row">
                     <div class="col-xs-12 col-md-6">
                         <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                               class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'} additional-information" method="post">
-                            {* Collapsable section *}
-                            <div id="collapse{$paymentMethodType|escape:'html':'UTF-8'}" class="adyen-collapsable collapse">
+                            {* If collapsing is NOT disabled due to config *}
+                            <div {if empty($removeCollapse)} id="collapse{$paymentMethodType|escape:'html':'UTF-8'}" class="adyen-collapsable collapse" {/if}>
                                 <div data-adyen-payment-container></div>
                                 {* Display payment extra info *}
                                 <div class="alert alert-info info-container" role="alert"></div>

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -30,21 +30,23 @@
          data-local-payment-method="{$paymentMethodType|escape:'html':'UTF-8'}"
     >
         <div class="col-xs-12 col-md-6">
-            <div class="adyen-payment-method-label">{l s='Pay with ' mod='adyenofficial'}{$paymentMethodName|escape:'html':'UTF-8'}</div>
-            <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
-                  class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'}" method="post">
-                <div data-adyen-payment-container></div>
-                <!-- Display payment extra info -->
-                <div class="alert alert-info info-container" role="alert"></div>
-                <!-- Display payment errors -->
-                <div class="alert alert-danger error-container" role="alert"></div>
-                <div data-adyen-payment-error-container role="alert"></div>
-                {if $isPrestaShop16 AND !in_array($paymentMethodType, $paymentMethodsWithPayButtonFromComponent|json_decode:1)}
-                    <button type="submit" class="button btn btn-default standard-checkout button-medium">
-                        <span>{l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i> </span>
-                    </button>
-                {/if}
-            </form>
+            <div class="payment_module">
+                <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
+                      class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'}" method="post">
+                    <div class="adyen-payment-method-label">{l s='Pay with ' mod='adyenofficial'}{$paymentMethodName|escape:'html':'UTF-8'}</div>
+                    <div data-adyen-payment-container></div>
+                    <!-- Display payment extra info -->
+                    <div class="alert alert-info info-container" role="alert"></div>
+                    <!-- Display payment errors -->
+                    <div class="alert alert-danger error-container" role="alert"></div>
+                    <div data-adyen-payment-error-container role="alert"></div>
+                    {if $isPrestaShop16 AND !in_array($paymentMethodType, $paymentMethodsWithPayButtonFromComponent|json_decode:1)}
+                        <button type="submit" class="button btn btn-default standard-checkout button-medium">
+                            <span>{l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i> </span>
+                        </button>
+                    {/if}
+                </form>
+            </div>
         </div>
     </div>
 {/if}

--- a/views/templates/front/payment-method.tpl
+++ b/views/templates/front/payment-method.tpl
@@ -28,6 +28,37 @@
 {else}
     <div class="row adyen-payment {$paymentMethodType|escape:'html':'UTF-8'}"
          data-local-payment-method="{$paymentMethodType|escape:'html':'UTF-8'}">
+        {if $isPrestaShop16}
+        <div class="col-xs-12 col-md-12">
+            <div class="payment_module collapser" data-toggle="collapse"
+                 data-target="#collapse{$paymentMethodType|escape:'html':'UTF-8'}" aria-expanded="true" aria-controls="collapseOne"
+                 style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$paymentMethodBrand|escape:'html':'UTF-8'}.png)">
+                <span class="adyen-payment-method-label">
+                    {l s='Pay with %s' sprintf=[{$paymentMethodName|escape:'html':'UTF-8'}] mod='adyenofficial'}
+                </span>
+                <div class="row">
+                    <div class="col-xs-12 col-md-6">
+                        <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
+                              class="adyen-payment-form-{$paymentMethodType|escape:'html':'UTF-8'} additional-information" method="post">
+                            <div id="collapse{$paymentMethodType|escape:'html':'UTF-8'}" class="collapse">
+                                <div data-adyen-payment-container></div>
+                                <!-- Display payment extra info -->
+                                <div class="alert alert-info info-container" role="alert"></div>
+                                <!-- Display payment errors -->
+                                <div class="alert alert-danger error-container" role="alert"></div>
+                                <div data-adyen-payment-error-container role="alert"></div>
+                                {if !in_array($paymentMethodType, $paymentMethodsWithPayButtonFromComponent|json_decode:1)}
+                                    <button type="submit" class="button btn btn-default standard-checkout button-medium">
+                                        <span>{l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i></span>
+                                    </button>
+                                {/if}
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {else}
         <div class="col-xs-12 col-md-6">
             <div class="payment_module">
                 <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
@@ -38,13 +69,9 @@
                     <!-- Display payment errors -->
                     <div class="alert alert-danger error-container" role="alert"></div>
                     <div data-adyen-payment-error-container role="alert"></div>
-                    {if $isPrestaShop16 AND !in_array($paymentMethodType, $paymentMethodsWithPayButtonFromComponent|json_decode:1)}
-                        <button type="submit" class="button btn btn-default standard-checkout button-medium">
-                            <span>{l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i> </span>
-                        </button>
-                    {/if}
                 </form>
             </div>
         </div>
+        {/if}
     </div>
 {/if}

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -31,9 +31,9 @@
         {if $isPrestaShop16}
             <div class="col-xs-12 col-md-12">
                 <div class="payment_module" style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$logoBrand|escape:'html':'UTF-8'}.png)">
-                    <span class="adyen-collapser adyen-payment-method-label collapsed" data-toggle="collapse"
-                          data-target="#collapse{$number|escape:'html':'UTF-8'}" aria-expanded="false"
-                          aria-controls="collapse{$number|escape:'html':'UTF-8'}">
+                    {* If collapsing is NOT disabled due to config *}
+                    <span {if empty($removeCollapse)} class="adyen-collapser adyen-payment-method-label collapsed" data-toggle="collapse" data-target="#collapse{$number|escape:'html':'UTF-8'}" aria-expanded="false" aria-controls="collapse{$number|escape:'html':'UTF-8'}"
+                            {else} class="adyen-payment-method-label" {/if}>
                         {l s='Pay by saved' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
                         {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
                     </span>
@@ -42,8 +42,8 @@
                             <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                                   class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}
                                   additional-information mb-0" method="post">
-                                {* Collapsable section *}
-                                <div id="collapse{$number|escape:'html':'UTF-8'}" class="adyen-collapsable collapse">
+                                {* If collapsing is NOT disabled due to config *}
+                                <div {if empty($removeCollapse)} id="collapse{$number|escape:'html':'UTF-8'}" class="adyen-collapsable collapse" {/if}>
                                     {* Display payment errors *}
                                     <div class="alert alert-danger error-container" role="alert"></div>
                                     {* Display payment container *}

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -33,7 +33,7 @@
                 <div class="payment_module adyen-collapser collapsed" data-toggle="collapse"
                      data-target="#collapse{$number|escape:'html':'UTF-8'}" aria-expanded="false"
                      aria-controls="collapse{$number|escape:'html':'UTF-8'}"
-                     style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$brand|escape:'html':'UTF-8'}.png)">
+                     style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$logoBrand|escape:'html':'UTF-8'}.png)">
                     <span class="adyen-payment-method-label">
                         {l s='Pay with saved ' mod='adyenofficial'}{$name|escape:'html':'UTF-8'}
                         {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -30,23 +30,25 @@
          data-stored-payment-api-id="{$storedPaymentApiId|escape:'html':'UTF-8'}"
     >
         <div class="col-xs-12 col-md-6">
-            {if $isPrestaShop16}
-            <div class="adyen-payment-method-label">
-                {l s='Pay with saved ' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
-                {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
+            <div class="payment_module">
+                <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
+                      class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}" method="post">
+                    {if $isPrestaShop16}
+                        <div class="adyen-payment-method-label">
+                            {l s='Pay with saved ' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
+                            {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
+                        </div>
+                    {/if}
+                    <!-- Display payment errors -->
+                    <div class="alert alert-danger error-container" role="alert"></div>
+                    <div data-adyen-payment-container></div>
+                    <div data-adyen-payment-error-container role="alert"></div>
+                    {if $isPrestaShop16}
+                        <button type="submit" class="button btn btn-default standard-checkout button-medium"><span>
+                             {l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i> </span></button>
+                    {/if}
+                </form>
             </div>
-            {/if}
-            <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
-                  class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}" method="post">
-                <!-- Display payment errors -->
-                <div class="alert alert-danger error-container" role="alert"></div>
-                <div data-adyen-payment-container></div>
-                <div data-adyen-payment-error-container role="alert"></div>
-                {if $isPrestaShop16}
-                    <button type="submit" class="button btn btn-default standard-checkout button-medium"><span>
-                         {l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i> </span></button>
-                {/if}
-            </form>
         </div>
     </div>
 {/if}

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -31,25 +31,30 @@
         {if $isPrestaShop16}
             <div class="col-xs-12 col-md-12">
                 <div class="payment_module collapser" data-toggle="collapse"
-                     data-target="#collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" aria-expanded="true" aria-controls="collapseOne">
+                     data-target="#collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" aria-expanded="true" aria-controls="collapseOne"
+                     style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$brand|escape:'html':'UTF-8'}.png)">
                     <span class="adyen-payment-method-label">
                         {l s='Pay with saved ' mod='adyenofficial'}{$name|escape:'html':'UTF-8'}
                         {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
                     </span>
-                    <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
-                          class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'} additional-information" method="post">
-                        <!-- Collapsable section -->
-                        <div id="collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" class="collapse">
-                            <!-- Display payment errors -->
-                            <div class="alert alert-danger error-container" role="alert"></div>
-                            <!-- Display payment container -->
-                            <div data-adyen-payment-container  class="adyen-payment-container"></div>
-                            <div data-adyen-payment-error-container role="alert"></div>
+                    <div class="row">
+                        <div class="col-xs-12 col-md-6">
+                            <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
+                                  class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'} additional-information" method="post">
+                                <!-- Collapsable section -->
+                                <div id="collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" class="collapse">
+                                    <!-- Display payment errors -->
+                                    <div class="alert alert-danger error-container" role="alert"></div>
+                                    <!-- Display payment container -->
+                                    <div data-adyen-payment-container  class="adyen-payment-container"></div>
+                                    <div data-adyen-payment-error-container role="alert"></div>
 
-                            <button type="submit" class="button btn btn-default standard-checkout button-medium"><span>
-                             {l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i> </span></button>
+                                    <button type="submit" class="button btn btn-default standard-checkout button-medium"><span>
+                                     {l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i> </span></button>
+                                </div>
+                            </form>
                         </div>
-                    </form>
+                    </div>
                 </div>
             </div>
         {else}

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -30,7 +30,7 @@
          data-stored-payment-api-id="{$storedPaymentApiId|escape:'html':'UTF-8'}">
         {if $isPrestaShop16}
             <div class="col-xs-12 col-md-12">
-                <div class="payment_module collapser" data-toggle="collapse"
+                <div class="payment_module adyen-collapser collapsed" data-toggle="collapse"
                      data-target="#collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" aria-expanded="true" aria-controls="collapseOne"
                      style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$brand|escape:'html':'UTF-8'}.png)">
                     <span class="adyen-payment-method-label">
@@ -40,7 +40,8 @@
                     <div class="row">
                         <div class="col-xs-12 col-md-6">
                             <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
-                                  class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'} additional-information" method="post">
+                                  class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}
+                                  additional-information mb-0" method="post">
                                 <!-- Collapsable section -->
                                 <div id="collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" class="collapse">
                                     <!-- Display payment errors -->

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -28,26 +28,43 @@
 {else}
     <div class="row adyen-payment"
          data-stored-payment-api-id="{$storedPaymentApiId|escape:'html':'UTF-8'}">
-        <div class="col-xs-12 col-md-6">
-            <div class="payment_module">
-                <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
-                      class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'} additional-information" method="post">
-                    {if $isPrestaShop16}
-                        <div class="adyen-payment-method-label">
-                            {l s='Pay with saved ' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
-                            {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
-                        </div>
-                    {/if}
-                    <!-- Display payment errors -->
-                    <div class="alert alert-danger error-container" role="alert"></div>
-                    <div data-adyen-payment-container></div>
-                    <div data-adyen-payment-error-container role="alert"></div>
-                    {if $isPrestaShop16}
-                        <button type="submit" class="button btn btn-default standard-checkout button-medium"><span>
+        {if $isPrestaShop16}
+            <div class="col-xs-12 col-md-12">
+                <div class="payment_module collapser" data-toggle="collapse"
+                     data-target="#collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" aria-expanded="true" aria-controls="collapseOne">
+                    <span class="adyen-payment-method-label">
+                        {l s='Pay with saved ' mod='adyenofficial'}{$name|escape:'html':'UTF-8'}
+                        {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
+                    </span>
+                    <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
+                          class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'} additional-information" method="post">
+                        <!-- Collapsable section -->
+                        <div id="collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" class="collapse">
+                            <!-- Display payment errors -->
+                            <div class="alert alert-danger error-container" role="alert"></div>
+                            <!-- Display payment container -->
+                            <div data-adyen-payment-container  class="adyen-payment-container"></div>
+                            <div data-adyen-payment-error-container role="alert"></div>
+
+                            <button type="submit" class="button btn btn-default standard-checkout button-medium"><span>
                              {l s='Pay' mod='adyenofficial'} <i class="icon-chevron-right right"></i> </span></button>
-                    {/if}
-                </form>
+                        </div>
+                    </form>
+                </div>
             </div>
-        </div>
+        {else}
+            <div class="col-xs-12 col-md-6">
+                <div class="payment_module">
+                    <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
+                          class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'} additional-information" method="post">
+                        <!-- Display payment errors -->
+                        <div class="alert alert-danger error-container" role="alert"></div>
+                        <!-- Display payment container -->
+                        <div data-adyen-payment-container class="adyen-payment-container"></div>
+                        <div data-adyen-payment-error-container role="alert"></div>
+                    </form>
+                </div>
+            </div>
+        {/if}
     </div>
 {/if}

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -30,11 +30,10 @@
          data-stored-payment-api-id="{$storedPaymentApiId|escape:'html':'UTF-8'}">
         {if $isPrestaShop16}
             <div class="col-xs-12 col-md-12">
-                <div class="payment_module adyen-collapser collapsed" data-toggle="collapse"
-                     data-target="#collapse{$number|escape:'html':'UTF-8'}" aria-expanded="false"
-                     aria-controls="collapse{$number|escape:'html':'UTF-8'}"
-                     style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$logoBrand|escape:'html':'UTF-8'}.png)">
-                    <span class="adyen-payment-method-label">
+                <div class="payment_module" style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$logoBrand|escape:'html':'UTF-8'}.png)">
+                    <span class="adyen-collapser adyen-payment-method-label collapsed" data-toggle="collapse"
+                          data-target="#collapse{$number|escape:'html':'UTF-8'}" aria-expanded="false"
+                          aria-controls="collapse{$number|escape:'html':'UTF-8'}">
                         {l s='Pay by saved' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
                         {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
                     </span>

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -27,8 +27,7 @@
     </form>
 {else}
     <div class="row adyen-payment"
-         data-stored-payment-api-id="{$storedPaymentApiId|escape:'html':'UTF-8'}"
-    >
+         data-stored-payment-api-id="{$storedPaymentApiId|escape:'html':'UTF-8'}">
         <div class="col-xs-12 col-md-6">
             <div class="payment_module">
                 <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
@@ -41,7 +40,7 @@
                     {/if}
                     <!-- Display payment errors -->
                     <div class="alert alert-danger error-container" role="alert"></div>
-                    <div data-adyen-payment-container></div>
+                    <div data-adyen-payment-container class="additional-information"></div>
                     <div data-adyen-payment-error-container role="alert"></div>
                     {if $isPrestaShop16}
                         <button type="submit" class="button btn btn-default standard-checkout button-medium"><span>

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -35,7 +35,7 @@
                      aria-controls="collapse{$number|escape:'html':'UTF-8'}"
                      style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$logoBrand|escape:'html':'UTF-8'}.png)">
                     <span class="adyen-payment-method-label">
-                        {l s='Pay with saved ' mod='adyenofficial'}{$name|escape:'html':'UTF-8'}
+                        {l s='Pay by saved' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
                         {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
                     </span>
                     <div class="row">

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -44,7 +44,7 @@
                                   class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}
                                   additional-information mb-0" method="post">
                                 {* Collapsable section *}
-                                <div id="collapse{$number|escape:'html':'UTF-8'}" class="collapse">
+                                <div id="collapse{$number|escape:'html':'UTF-8'}" class="adyen-collapsable collapse">
                                     {* Display payment errors *}
                                     <div class="alert alert-danger error-container" role="alert"></div>
                                     {* Display payment container *}

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -43,11 +43,11 @@
                             <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                                   class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}
                                   additional-information mb-0" method="post">
-                                <!-- Collapsable section -->
+                                {* Collapsable section *}
                                 <div id="collapse{$number|escape:'html':'UTF-8'}" class="collapse">
-                                    <!-- Display payment errors -->
+                                    {* Display payment errors *}
                                     <div class="alert alert-danger error-container" role="alert"></div>
-                                    <!-- Display payment container -->
+                                    {* Display payment container *}
                                     <div data-adyen-payment-container  class="adyen-payment-container"></div>
                                     <div data-adyen-payment-error-container role="alert"></div>
 
@@ -64,9 +64,9 @@
                 <div class="payment_module">
                     <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                           class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'} additional-information" method="post">
-                        <!-- Display payment errors -->
+                        {* Display payment errors *}
                         <div class="alert alert-danger error-container" role="alert"></div>
-                        <!-- Display payment container -->
+                        {* Display payment container *}
                         <div data-adyen-payment-container class="adyen-payment-container"></div>
                         <div data-adyen-payment-error-container role="alert"></div>
                     </form>

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -31,7 +31,7 @@
         <div class="col-xs-12 col-md-6">
             <div class="payment_module">
                 <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
-                      class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}" method="post">
+                      class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'} additional-information" method="post">
                     {if $isPrestaShop16}
                         <div class="adyen-payment-method-label">
                             {l s='Pay with saved ' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
@@ -40,7 +40,7 @@
                     {/if}
                     <!-- Display payment errors -->
                     <div class="alert alert-danger error-container" role="alert"></div>
-                    <div data-adyen-payment-container class="additional-information"></div>
+                    <div data-adyen-payment-container></div>
                     <div data-adyen-payment-error-container role="alert"></div>
                     {if $isPrestaShop16}
                         <button type="submit" class="button btn btn-default standard-checkout button-medium"><span>

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -31,8 +31,8 @@
         {if $isPrestaShop16}
             <div class="col-xs-12 col-md-12">
                 <div class="payment_module" style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$logoBrand|escape:'html':'UTF-8'}.png)">
-                    {* If collapsing is NOT disabled due to config *}
-                    <span {if empty($removeCollapse)} class="adyen-collapser adyen-payment-method-label collapsed" data-toggle="collapse" data-target="#collapse{$number|escape:'html':'UTF-8'}" aria-expanded="false" aria-controls="collapse{$number|escape:'html':'UTF-8'}"
+                    {* If collapsing is enabled by config *}
+                    <span {if $collapsePayments} class="adyen-collapser adyen-payment-method-label collapsed" data-toggle="collapse" data-target="#collapse{$number|escape:'html':'UTF-8'}" aria-expanded="false" aria-controls="collapse{$number|escape:'html':'UTF-8'}"
                             {else} class="adyen-payment-method-label" {/if}>
                         {l s='Pay by saved' mod='adyenofficial'} {$name|escape:'html':'UTF-8'}
                         {l s=' ending: ' mod='adyenofficial'} {$number|escape:'html':'UTF-8'}
@@ -42,8 +42,8 @@
                             <form action="{$paymentProcessUrl|escape:'html':'UTF-8'}"
                                   class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}
                                   additional-information mb-0" method="post">
-                                {* If collapsing is NOT disabled due to config *}
-                                <div {if empty($removeCollapse)} id="collapse{$number|escape:'html':'UTF-8'}" class="adyen-collapsable collapse" {/if}>
+                                {* If collapsing is enabled by config *}
+                                <div {if $collapsePayments} id="collapse{$number|escape:'html':'UTF-8'}" class="adyen-collapsable collapse" {/if}>
                                     {* Display payment errors *}
                                     <div class="alert alert-danger error-container" role="alert"></div>
                                     {* Display payment container *}

--- a/views/templates/front/stored-payment-method.tpl
+++ b/views/templates/front/stored-payment-method.tpl
@@ -31,7 +31,8 @@
         {if $isPrestaShop16}
             <div class="col-xs-12 col-md-12">
                 <div class="payment_module adyen-collapser collapsed" data-toggle="collapse"
-                     data-target="#collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" aria-expanded="true" aria-controls="collapseOne"
+                     data-target="#collapse{$number|escape:'html':'UTF-8'}" aria-expanded="false"
+                     aria-controls="collapse{$number|escape:'html':'UTF-8'}"
                      style="background-image: url(https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/{$brand|escape:'html':'UTF-8'}.png)">
                     <span class="adyen-payment-method-label">
                         {l s='Pay with saved ' mod='adyenofficial'}{$name|escape:'html':'UTF-8'}
@@ -43,7 +44,7 @@
                                   class="adyen-payment-form-{$storedPaymentApiId|escape:'html':'UTF-8'}
                                   additional-information mb-0" method="post">
                                 <!-- Collapsable section -->
-                                <div id="collapse{$storedPaymentApiId|escape:'html':'UTF-8'}" class="collapse">
+                                <div id="collapse{$number|escape:'html':'UTF-8'}" class="collapse">
                                     <!-- Display payment errors -->
                                     <div class="alert alert-danger error-container" role="alert"></div>
                                     <!-- Display payment container -->


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Copy the default html structure of a default payment method when displaying our payment methods.
It helps our merchants with the customization, templates and styling.

## Tested scenarios
* Payment methods clearly shown on 1.7
![Screen Shot 2021-03-11 at 9 28 58 AM](https://user-images.githubusercontent.com/11156828/110758703-1a48bf80-824d-11eb-8bb0-111b66a20ba6.png)


* Payment methods clearly shown on 1.6
![Screen Shot 2021-03-11 at 9 29 43 AM](https://user-images.githubusercontent.com/11156828/110758711-1c128300-824d-11eb-9add-f760142c4177.png)

