### PR TITLE
[PW-4295] - Update payment needs attention check

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -466,7 +466,8 @@ class AdyenOfficial extends PaymentModule
             'ADYEN_APPLE_PAY_MERCHANT_NAME',
             'ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER',
             'ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID',
-            'ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER'
+            'ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER',
+            'ADYEN_STRICT_ORDER_CHECK'
         );
 
         $result = true;
@@ -536,6 +537,7 @@ class AdyenOfficial extends PaymentModule
             // get post values
             $merchant_account = (string)Tools::getValue('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = (string)Tools::getValue('ADYEN_INTEGRATOR_NAME');
+            $strict_order_check = (string)Tools::getValue('ADYEN_STRICT_ORDER_CHECK');
             $mode = (string)Tools::getValue('ADYEN_MODE');
             $notification_username = (string)Tools::getValue('ADYEN_NOTI_USERNAME');
             $notification_password = (string)Tools::getValue('ADYEN_NOTI_PASSWORD');
@@ -579,6 +581,7 @@ class AdyenOfficial extends PaymentModule
             if ($output == null) {
                 Configuration::updateValue('ADYEN_MERCHANT_ACCOUNT', $merchant_account);
                 Configuration::updateValue('ADYEN_INTEGRATOR_NAME', $integrator_name);
+                Configuration::updateValue('ADYEN_STRICT_ORDER_CHECK', $strict_order_check);
                 Configuration::updateValue('ADYEN_MODE', $mode);
                 Configuration::updateValue('ADYEN_NOTI_USERNAME', $notification_username);
                 Configuration::updateValue('ADYEN_LIVE_ENDPOINT_URL_PREFIX', $live_endpoint_url_prefix);
@@ -967,6 +970,27 @@ class AdyenOfficial extends PaymentModule
             'hint' => $this->l('Name of the integrator used. Leave blank if no integrator was utilised.')
         );
 
+        // Strict order check
+        $fields_form[2]['form']['input'][] = array(
+            'type' => 'radio',
+            'label' => $this->l('Strict order check'),
+            'name' => 'ADYEN_STRICT_ORDER_CHECK',
+            'values' => array(
+                array(
+                    'id' => 'enable',
+                    'value' => 1,
+                    'label' => $this->l('Enable')
+                ),
+                array(
+                    'id' => 'disable',
+                    'value' => 0,
+                    'label' => $this->l('Disable')
+                )
+            ),
+            // phpcs:ignore Generic.Files.LineLength.TooLong
+            'hint' => $this->l('Enable a check which verifies that the amounts and currencies of the Adyen response and the Adyen notification are both equivalent to the amounts and currencies of the Order and Cart entities.')
+        );
+
         $helper = new HelperForm();
 
         // Module, token and currentIndex
@@ -1005,6 +1029,7 @@ class AdyenOfficial extends PaymentModule
             // get settings from post because post can give errors and you want to keep values
             $merchant_account = (string)Tools::getValue('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = (string)Tools::getValue('ADYEN_INTEGRATOR_NAME');
+            $strict_order_check = (string)Tools::getValue('ADYEN_STRICT_ORDER_CHECK');
             $mode = (string)Tools::getValue('ADYEN_MODE');
             $notification_username = (string)Tools::getValue('ADYEN_NOTI_USERNAME');
             $cron_job_token = Tools::getValue('ADYEN_CRONJOB_TOKEN');
@@ -1018,6 +1043,7 @@ class AdyenOfficial extends PaymentModule
         } else {
             $merchant_account = Configuration::get('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = Configuration::get('ADYEN_INTEGRATOR_NAME');
+            $strict_order_check = Configuration::get('ADYEN_STRICT_ORDER_CHECK');
             $mode = Configuration::get('ADYEN_MODE');
             $notification_username = Configuration::get('ADYEN_NOTI_USERNAME');
             $cron_job_token = $cronjobToken;
@@ -1034,6 +1060,7 @@ class AdyenOfficial extends PaymentModule
         // Load current value
         $helper->fields_value['ADYEN_MERCHANT_ACCOUNT'] = $merchant_account;
         $helper->fields_value['ADYEN_INTEGRATOR_NAME'] = $integrator_name;
+        $helper->fields_value['ADYEN_STRICT_ORDER_CHECK'] = $strict_order_check;
         $helper->fields_value['ADYEN_MODE'] = $mode;
         $helper->fields_value['ADYEN_NOTI_USERNAME'] = $notification_username;
         $helper->fields_value['ADYEN_CRONJOB_TOKEN'] = $cron_job_token;

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -466,8 +466,7 @@ class AdyenOfficial extends PaymentModule
             'ADYEN_APPLE_PAY_MERCHANT_NAME',
             'ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER',
             'ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID',
-            'ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER',
-            'ADYEN_STRICT_ORDER_CHECK'
+            'ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER'
         );
 
         $result = true;
@@ -537,7 +536,6 @@ class AdyenOfficial extends PaymentModule
             // get post values
             $merchant_account = (string)Tools::getValue('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = (string)Tools::getValue('ADYEN_INTEGRATOR_NAME');
-            $strict_order_check = (string)Tools::getValue('ADYEN_STRICT_ORDER_CHECK');
             $mode = (string)Tools::getValue('ADYEN_MODE');
             $notification_username = (string)Tools::getValue('ADYEN_NOTI_USERNAME');
             $notification_password = (string)Tools::getValue('ADYEN_NOTI_PASSWORD');
@@ -581,7 +579,6 @@ class AdyenOfficial extends PaymentModule
             if ($output == null) {
                 Configuration::updateValue('ADYEN_MERCHANT_ACCOUNT', $merchant_account);
                 Configuration::updateValue('ADYEN_INTEGRATOR_NAME', $integrator_name);
-                Configuration::updateValue('ADYEN_STRICT_ORDER_CHECK', $strict_order_check);
                 Configuration::updateValue('ADYEN_MODE', $mode);
                 Configuration::updateValue('ADYEN_NOTI_USERNAME', $notification_username);
                 Configuration::updateValue('ADYEN_LIVE_ENDPOINT_URL_PREFIX', $live_endpoint_url_prefix);
@@ -970,27 +967,6 @@ class AdyenOfficial extends PaymentModule
             'hint' => $this->l('Name of the integrator used. Leave blank if no integrator was utilised.')
         );
 
-        // Strict order check
-        $fields_form[2]['form']['input'][] = array(
-            'type' => 'radio',
-            'label' => $this->l('Strict order check'),
-            'name' => 'ADYEN_STRICT_ORDER_CHECK',
-            'values' => array(
-                array(
-                    'id' => 'enable',
-                    'value' => 1,
-                    'label' => $this->l('Enable')
-                ),
-                array(
-                    'id' => 'disable',
-                    'value' => 0,
-                    'label' => $this->l('Disable')
-                )
-            ),
-            // phpcs:ignore Generic.Files.LineLength.TooLong
-            'hint' => $this->l('Enable a check which verifies that the amounts and currencies of the Adyen response and the Adyen notification are both equivalent to the amounts and currencies of the Order and Cart entities.')
-        );
-
         $helper = new HelperForm();
 
         // Module, token and currentIndex
@@ -1029,7 +1005,6 @@ class AdyenOfficial extends PaymentModule
             // get settings from post because post can give errors and you want to keep values
             $merchant_account = (string)Tools::getValue('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = (string)Tools::getValue('ADYEN_INTEGRATOR_NAME');
-            $strict_order_check = (string)Tools::getValue('ADYEN_STRICT_ORDER_CHECK');
             $mode = (string)Tools::getValue('ADYEN_MODE');
             $notification_username = (string)Tools::getValue('ADYEN_NOTI_USERNAME');
             $cron_job_token = Tools::getValue('ADYEN_CRONJOB_TOKEN');
@@ -1043,7 +1018,6 @@ class AdyenOfficial extends PaymentModule
         } else {
             $merchant_account = Configuration::get('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = Configuration::get('ADYEN_INTEGRATOR_NAME');
-            $strict_order_check = Configuration::get('ADYEN_STRICT_ORDER_CHECK');
             $mode = Configuration::get('ADYEN_MODE');
             $notification_username = Configuration::get('ADYEN_NOTI_USERNAME');
             $cron_job_token = $cronjobToken;
@@ -1060,7 +1034,6 @@ class AdyenOfficial extends PaymentModule
         // Load current value
         $helper->fields_value['ADYEN_MERCHANT_ACCOUNT'] = $merchant_account;
         $helper->fields_value['ADYEN_INTEGRATOR_NAME'] = $integrator_name;
-        $helper->fields_value['ADYEN_STRICT_ORDER_CHECK'] = $strict_order_check;
         $helper->fields_value['ADYEN_MODE'] = $mode;
         $helper->fields_value['ADYEN_NOTI_USERNAME'] = $notification_username;
         $helper->fields_value['ADYEN_CRONJOB_TOKEN'] = $cron_job_token;

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -378,28 +378,19 @@ class NotificationProcessor
         }
 
         $cartCurrency = \Currency::getCurrency($cart->id_currency);
-        $orderCurrency = \Currency::getCurrency($order->id_currency);
         $cartCurrencyIso = $cartCurrency['iso_code'];
-        $orderCurrencyIso = $orderCurrency['iso_code'];
 
         $cartTotalMinorUnits = $this->utilCurrency->sanitize($cart->getOrderTotal(), $cartCurrencyIso);
-        $orderTotalMinorUnits = $this->utilCurrency->sanitize($order->getTotalPaid(), $orderCurrencyIso);
 
         if ($notification['amount_currency'] !== $cartCurrencyIso ||
-            $notification['amount_currency'] !== $orderCurrencyIso ||
-            (int)$notification['amount_value'] !== $cartTotalMinorUnits ||
-            (int)$notification['amount_value'] !== $orderTotalMinorUnits) {
+            (int)$notification['amount_value'] !== $cartTotalMinorUnits) {
             $this->logger->addAdyenNotification(
                 sprintf(
-                    'Notification with id (%s), amount (%s) and currency (%s) contains an incompatible ' .
-                    'amount/currency with Order with id (%s), amount (%s) and currency (%s) OR Cart with id (%s), ' .
-                    'amount (%s) and currency (%s).',
+                    'Notification: id (%s), amount (%s) and currency (%s) contains an incompatible ' .
+                    'amount/currency with Cart: id (%s), amount (%s) and currency (%s).',
                     $notification['entity_id'],
                     $notification['amount_value'],
                     $notification['amount_currency'],
-                    $order->id,
-                    $orderTotalMinorUnits,
-                    $orderCurrencyIso,
                     $cart->id,
                     $cartTotalMinorUnits,
                     $cartCurrencyIso

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -390,9 +390,22 @@ class NotificationProcessor
             (int)$notification['amount_value'] !== $cartTotalMinorUnits ||
             (int)$notification['amount_value'] !== $orderTotalMinorUnits) {
             $this->logger->addAdyenNotification(
-                sprintf('Notification with id (%s) contains an incompatible amount/currency with ' .
-                    'Order (%s) or Cart (%s)', $notification['entity_id'], $order->id, $cart->id)
+                sprintf(
+                    'Notification with id (%s), amount (%s) and currency (%s) contains an incompatible ' .
+                    'amount/currency with Order with id (%s), amount (%s) and currency (%s) OR Cart with id (%s), ' .
+                    'amount (%s) and currency (%s).',
+                    $notification['entity_id'],
+                    $notification['amount_value'],
+                    $notification['amount_currency'],
+                    $order->id,
+                    $orderTotalMinorUnits,
+                    $orderCurrencyIso,
+                    $cart->id,
+                    $cartTotalMinorUnits,
+                    $cartCurrencyIso
+                )
             );
+
             return false;
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In the [check](https://github.com/Adyen/adyen-prestashop/blob/develop/service/notification/NotificationProcessor.php#L388-L397) which compares the amounts and currencies, we should make the following changes:

* Double check if order values should be validated as well or only cart details should

* Log the cart and order details (similar to `FrontController::validateCartOrderTotalAndCurrency`)

## Tested scenarios
* Process notification after normal payment on 1.7
* Process notification after 3DS payment on 1.7
* Process notification after 3DS payment on 1.6
