### PR TITLE
[PW-4312] Order button not shown

### DIFF
--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -88,9 +88,12 @@ jQuery(document).ready(function() {
 
             // Adyen payment method
             if (selectedPaymentForm.length > 0) {
+
+                // not local payment method
                 if (!('localPaymentMethod' in
                     selectedPaymentForm.get(0).dataset)) {
-                    // not local payment method
+
+                    resetPrestaShopPlaceOrderButtonVisibility();
                     return;
                 }
 
@@ -104,8 +107,17 @@ jQuery(document).ready(function() {
                         prestaShopPlaceOrderButton.show();
                     }
                 }
+            } else {
+                // In 1.7 in case the pay button is hidden and the customer selects a non adyen method
+                resetPrestaShopPlaceOrderButtonVisibility();
             }
         });
+    }
+
+    function resetPrestaShopPlaceOrderButtonVisibility() {
+        if (!IS_PRESTA_SHOP_16 && !prestaShopPlaceOrderButton.is(":visible")) {
+            prestaShopPlaceOrderButton.show();
+        }
     }
 
     function showRedirectErrorMessage(message) {


### PR DESCRIPTION
## Summary
Fix prestashop pay button visibility in 1.7

In case the user is using a non adyen payment method or a stored payment
from adyen the pay button can remain hidden if a prior selected payment
method hides it

## Tested scenarios
Switching payment methods using adyen wallet payment methods, stored, normal payment methods and non adyen payment methods