### PR TITLE
[PW-4350] Multiple order_payments created on redirect

### DIFF
--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -255,7 +255,7 @@ abstract class FrontController extends \ModuleFrontController
                 if ($cart->OrderExists() !== false) {
                     $order = $this->orderAdapter->getOrderByCartId($cart->id);
                     if (\Validate::isLoadedObject($order)) {
-                        $order->setCurrentState(\Configuration::get('PS_OS_CANCELED'));
+                        $this->createOrUpdateOrder($cart, $extraVars, $customer, \Configuration::get('PS_OS_CANCELED'));
                     } else {
                         $this->logger->addError('Order cannot be loaded for cart id: ' . $cart->id);
                     }
@@ -482,7 +482,7 @@ abstract class FrontController extends \ModuleFrontController
         if ($cart->OrderExists() !== false) {
             $order = $this->orderAdapter->getOrderByCartId($cart->id);
             if (\Validate::isLoadedObject($order)) {
-                $order->setCurrentState($orderStatus);
+                $this->orderService->updateOrderState($order, $orderStatus, $extraVars);
             } else {
                 $this->logger->addError('Order cannot be loaded for cart id: ' . $cart->id);
             }

--- a/service/Order.php
+++ b/service/Order.php
@@ -24,8 +24,23 @@
 
 namespace Adyen\PrestaShop\service;
 
+use Adyen\PrestaShop\service\adapter\classes\ServiceLocator;
+
 class Order
 {
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * Order constructor.
+     */
+    public function __construct()
+    {
+        $this->logger = ServiceLocator::get('Adyen\PrestaShop\service\Logger');
+    }
+
     public function addPaymentDataToOrderFromResponse($order, $response)
     {
         if (\Validate::isLoadedObject($order)) {
@@ -86,5 +101,53 @@ class Order
         }
 
         return null;
+    }
+
+    /**
+     * @param $order
+     * @param $orderStateId
+     * @param $extraVars
+     *
+     * @return bool
+     */
+    public function updateOrderState($order, $orderStateId, $extraVars)
+    {
+        // check if the new order state is the same as the current state
+        $currentOrderStateId = (int) $order->getCurrentState();
+
+        if ($currentOrderStateId === $orderStateId) {
+            // duplicate order state handling, no need to update the order
+            return false;
+        }
+
+        // Change order history in case the order updates to a new order state
+        $orderHistory = new \OrderHistory();
+        $orderHistory->id_order = $order->id;
+
+        $useExistingPayment = !$order->hasInvoice();
+
+        $orderHistory->changeIdOrderState(
+            $orderStateId,
+            $order->id,
+            $useExistingPayment
+        );
+
+        if (!$orderHistory->addWithemail()) {
+            $this->logger->addError('Email was not sent upon order state update', ["order id" => $order->id, "new state id" => $orderStateId]);
+        }
+
+        $orderPaymentCollection = $order->getOrderPaymentCollection();
+        // TODO check if order payment is Adyen $orderPaymentCollection->where('payment_method', '=', 'Adyen');
+
+        /** @var \OrderPayment[] $orderPayments */
+        $orderPayments = $orderPaymentCollection->getAll();
+        foreach ($orderPayments as $orderPayment) {
+            if (\Validate::isLoadedObject($orderPayment)) {
+                if (empty($orderPayment->transaction_id) && !empty($extraVars['transaction_id'])) {
+                    $orderPayment->transaction_id = $extraVars['transaction_id'];
+                    $orderPayment->save();
+                }
+            }
+        }
     }
 }

--- a/service/Order.php
+++ b/service/Order.php
@@ -113,7 +113,7 @@ class Order
     public function updateOrderState($order, $orderStateId, $extraVars)
     {
         // check if the new order state is the same as the current state
-        $currentOrderStateId = (int) $order->getCurrentState();
+        $currentOrderStateId = (int)$order->getCurrentState();
 
         if ($currentOrderStateId === $orderStateId) {
             // duplicate order state handling, no need to update the order
@@ -133,7 +133,10 @@ class Order
         );
 
         if (!$orderHistory->addWithemail()) {
-            $this->logger->addError('Email was not sent upon order state update', ["order id" => $order->id, "new state id" => $orderStateId]);
+            $this->logger->addError(
+                'Email was not sent upon order state update',
+                array("order id" => $order->id, "new state id" => $orderStateId)
+            );
         }
 
         $orderPaymentCollection = $order->getOrderPaymentCollection();

--- a/service/Order.php
+++ b/service/Order.php
@@ -140,7 +140,7 @@ class Order
         }
 
         $orderPaymentCollection = $order->getOrderPaymentCollection();
-        // TODO check if order payment is Adyen $orderPaymentCollection->where('payment_method', '=', 'Adyen');
+        $orderPaymentCollection->where('payment_method', '=', 'Adyen');
 
         /** @var \OrderPayment[] $orderPayments */
         $orderPayments = $orderPaymentCollection->getAll();

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -165,13 +165,21 @@ class NotificationProcessor
             return true;
         }
 
+        // Update transaction_id with the original psp reference if available in the notification
+        $extraVars = [];
+        if (!empty($unprocessedNotification['original_reference'])) {
+            $extraVars['transaction_id'] = $unprocessedNotification['original_reference'];
+        } else {
+            $extraVars['transaction_id'] = $unprocessedNotification['pspreference'];
+        }
+
         // Process notifications based on it's event code
         switch ($unprocessedNotification['event_code']) {
             case AdyenNotification::AUTHORISATION:
                 if ('true' === $unprocessedNotification['success']) {
                     // If notification data does not match cart and order, set to PAYMENT_NEEDS_ATTENTION
                     if (!$this->validateWithCartAndOrder($unprocessedNotification, $order)) {
-                        $order->setCurrentState(\Configuration::get('ADYEN_OS_PAYMENT_NEEDS_ATTENTION'));
+                        $this->orderService->updateOrderState($order, \Configuration::get('ADYEN_OS_PAYMENT_NEEDS_ATTENTION'), $extraVars);
                         $this->orderService->addPaymentDataToOrderFromResponse($order, $unprocessedNotification);
 
                         return true;
@@ -179,23 +187,10 @@ class NotificationProcessor
 
                     // If not in a final status, set to PAYMENT
                     if ($this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
-                        $order->setCurrentState(\Configuration::get('PS_OS_PAYMENT'));
-
+                        $this->orderService->updateOrderState($order, \Configuration::get('PS_OS_PAYMENT'), $extraVars);
                         // Add additional data to order if there is any (only possible when the notification success is
                         // true
                         $this->orderService->addPaymentDataToOrderFromResponse($order, $unprocessedNotification);
-                    }
-
-                    // In case psp reference is missing from the order_payment add it
-                    $storedPspReference = $this->orderService->getPspReferenceForOrderPayment($order);
-                    if (empty($storedPspReference)) {
-                        if (!empty($unprocessedNotification['original_reference'])) {
-                            $pspReference = $unprocessedNotification['original_reference'];
-                        } else {
-                            $pspReference = $unprocessedNotification['pspreference'];
-                        }
-
-                        $this->orderService->addPspReferenceForOrderPayment($order, $pspReference);
                     }
                 } else { // Notification success is 'false'
                     // Order state is not canceled yet
@@ -203,7 +198,7 @@ class NotificationProcessor
                         // If order has a non final status, set to cancelled
                         if ($this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
                             // Moves order to canceled
-                            $order->setCurrentState(\Configuration::get('PS_OS_CANCELED'));
+                            $this->orderService->updateOrderState($order, \Configuration::get('PS_OS_CANCELED'), $extraVars);
                         } else {
                             // Add this log when the notification is ignore because an authorisation success true
                             // notification has already been processed for the same order
@@ -226,10 +221,9 @@ class NotificationProcessor
                 if ('true' === $unprocessedNotification['success']) {
                     // Moves order to canceled if order status is waiting for payment
                     if ($order->getCurrentState() === \Configuration::get('ADYEN_OS_WAITING_FOR_PAYMENT')) {
-                        $order->setCurrentState(\Configuration::get('PS_OS_CANCELED'));
+                        $this->orderService->updateOrderState($order, \Configuration::get('PS_OS_CANCELED'), $extraVars);
                     }
                 }
-
 
                 $this->adyenPaymentResponse->deletePaymentResponseByCartId(
                     $unprocessedNotification['merchant_reference']

--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -166,7 +166,7 @@ class NotificationProcessor
         }
 
         // Update transaction_id with the original psp reference if available in the notification
-        $extraVars = [];
+        $extraVars = array();
         if (!empty($unprocessedNotification['original_reference'])) {
             $extraVars['transaction_id'] = $unprocessedNotification['original_reference'];
         } else {
@@ -179,7 +179,11 @@ class NotificationProcessor
                 if ('true' === $unprocessedNotification['success']) {
                     // If notification data does not match cart and order, set to PAYMENT_NEEDS_ATTENTION
                     if (!$this->validateWithCartAndOrder($unprocessedNotification, $order)) {
-                        $this->orderService->updateOrderState($order, \Configuration::get('ADYEN_OS_PAYMENT_NEEDS_ATTENTION'), $extraVars);
+                        $this->orderService->updateOrderState(
+                            $order,
+                            \Configuration::get('ADYEN_OS_PAYMENT_NEEDS_ATTENTION'),
+                            $extraVars
+                        );
                         $this->orderService->addPaymentDataToOrderFromResponse($order, $unprocessedNotification);
 
                         return true;
@@ -198,7 +202,11 @@ class NotificationProcessor
                         // If order has a non final status, set to cancelled
                         if ($this->isCurrentOrderStatusANonFinalStatus($order->getCurrentState())) {
                             // Moves order to canceled
-                            $this->orderService->updateOrderState($order, \Configuration::get('PS_OS_CANCELED'), $extraVars);
+                            $this->orderService->updateOrderState(
+                                $order,
+                                \Configuration::get('PS_OS_CANCELED'),
+                                $extraVars
+                            );
                         } else {
                             // Add this log when the notification is ignore because an authorisation success true
                             // notification has already been processed for the same order
@@ -214,14 +222,18 @@ class NotificationProcessor
                 $this->adyenPaymentResponse->deletePaymentResponseByCartId(
                     $unprocessedNotification['merchant_reference']
                 );
-                
+
                 break;
             case AdyenNotification::OFFER_CLOSED:
                 // Notification success is 'true' AND current status is ADYEN_OS_WAITING_FOR_PAYMENT
                 if ('true' === $unprocessedNotification['success']) {
                     // Moves order to canceled if order status is waiting for payment
                     if ($order->getCurrentState() === \Configuration::get('ADYEN_OS_WAITING_FOR_PAYMENT')) {
-                        $this->orderService->updateOrderState($order, \Configuration::get('PS_OS_CANCELED'), $extraVars);
+                        $this->orderService->updateOrderState(
+                            $order,
+                            \Configuration::get('PS_OS_CANCELED'),
+                            $extraVars
+                        );
                     }
                 }
 


### PR DESCRIPTION
## Summary
Stop using setCurrentState() and update the order history with own logic
Introduce updateOrderState() in the orderService
Replace all setCurrentState with new updateOrderState()
Update transaction_id with the the original pspreference
