### PR TITLE
[PW-4246] Add new enable stored payment methods configuration field

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1166,7 +1166,10 @@ class AdyenOfficial extends PaymentModule
         //retrieve payment methods
         $paymentMethods = $this->helper_data->fetchPaymentMethods($this->context->cart, $this->context->language);
 
-        if (!$this->context->customer->is_guest && !empty($paymentMethods['storedPaymentMethods'])) {
+        if (!$this->context->customer->is_guest &&
+            !empty($paymentMethods['storedPaymentMethods']) &&
+            Configuration::get('ADYEN_ENABLE_STORED_PAYMENT_METHODS')
+        ) {
             $storedPaymentMethods = $paymentMethods['storedPaymentMethods'];
             foreach ($storedPaymentMethods as $storedPaymentMethod) {
                 if (!empty($storedPaymentMethod)) {
@@ -1270,7 +1273,10 @@ class AdyenOfficial extends PaymentModule
 
         $payments = "";
         $paymentMethods = $this->helper_data->fetchPaymentMethods($this->context->cart, $this->context->language);
-        if (!$this->context->customer->is_guest && !empty($paymentMethods['storedPaymentMethods'])) {
+        if (!$this->context->customer->is_guest &&
+            !empty($paymentMethods['storedPaymentMethods']) &&
+            Configuration::get('ADYEN_ENABLE_STORED_PAYMENT_METHODS')
+        ) {
             $payments .= $this->getOneClickPaymentMethods($paymentMethods);
         }
 

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -240,6 +240,8 @@ class AdyenOfficial extends PaymentModule
         }
     }
 
+    // TODO set default value 1 for ADYEN_ENABLE_STORED_PAYMENT_METHODS and 0 for ADYEN_PAYMENT_DISPLAY_COLLAPSE as soon as the PW-4366 is merged
+
     /**
      * @return bool
      */
@@ -509,7 +511,8 @@ class AdyenOfficial extends PaymentModule
             'ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER',
             'ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID',
             'ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER',
-            'ADYEN_PAYMENT_DISPLAY_COLLAPSE'
+            'ADYEN_PAYMENT_DISPLAY_COLLAPSE',
+            'ADYEN_ENABLE_STORED_PAYMENT_METHODS',
         );
 
         $result = true;
@@ -594,7 +597,7 @@ class AdyenOfficial extends PaymentModule
             $google_pay_gateway_merchant_id = Tools::getValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
             $payment_display_collapse = Tools::getValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
-
+            $enable_stored_payment_methods = Tools::getValue('ADYEN_ENABLE_STORED_PAYMENT_METHODS');
 
             // validating the input
             if (empty($merchant_account) || !Validate::isGenericName($merchant_account)) {
@@ -634,6 +637,7 @@ class AdyenOfficial extends PaymentModule
                 Configuration::updateValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID', $google_pay_gateway_merchant_id);
                 Configuration::updateValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER', $google_pay_merchant_identifier);
                 Configuration::updateValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE', $payment_display_collapse);
+                Configuration::updateValue('ADYEN_ENABLE_STORED_PAYMENT_METHODS', $enable_stored_payment_methods);
 
                 if (!empty($notification_password)) {
                     Configuration::updateValue('ADYEN_NOTI_PASSWORD', $this->crypto->encrypt($notification_password));
@@ -949,6 +953,27 @@ class AdyenOfficial extends PaymentModule
             )
         );
 
+        $fields_form[1]['form']['input'][] = array(
+            'type' => 'radio',
+            'label' => $this->l('Enable stored payment methods'),
+            'name' => 'ADYEN_ENABLE_STORED_PAYMENT_METHODS',
+            'values' => array(
+                array(
+                    'id' => 'enable',
+                    'value' => 1,
+                    'label' => $this->l('Enable')
+                ),
+                array(
+                    'id' => 'disable',
+                    'value' => 0,
+                    'label' => $this->l('Disable')
+                )
+            ),
+            'is_bool' => true,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
+            'hint' => 'Indicates whether the customers can store and use payment methods during checkout for one click checkout purposes'
+        );
+
         // Apple pay merchant name input
         $fields_form[1]['form']['input'][] = array(
             'type' => 'text',
@@ -1090,6 +1115,7 @@ class AdyenOfficial extends PaymentModule
             $google_pay_gateway_merchant_id = Tools::getValue('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
             $payment_display_collapse = Tools::getValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
+            $enable_stored_payment_methods = Tools::getValue('ADYEN_ENABLE_STORED_PAYMENT_METHODS');
         } else {
             $merchant_account = Configuration::get('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = Configuration::get('ADYEN_INTEGRATOR_NAME');
@@ -1104,7 +1130,8 @@ class AdyenOfficial extends PaymentModule
             $apple_pay_merchant_identifier = Configuration::get('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER');
             $google_pay_gateway_merchant_id = Configuration::get('ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID');
             $google_pay_merchant_identifier = Configuration::get('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
-            $payment_display_collapse = Tools::getValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
+            $payment_display_collapse = Configuration::get('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
+            $enable_stored_payment_methods = Configuration::get('ADYEN_ENABLE_STORED_PAYMENT_METHODS');
         }
 
         // Load current value
@@ -1121,6 +1148,7 @@ class AdyenOfficial extends PaymentModule
         $helper->fields_value['ADYEN_GOOGLE_PAY_GATEWAY_MERCHANT_ID'] = $google_pay_gateway_merchant_id;
         $helper->fields_value['ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER'] = $google_pay_merchant_identifier;
         $helper->fields_value['ADYEN_PAYMENT_DISPLAY_COLLAPSE'] = $payment_display_collapse;
+        $helper->fields_value['ADYEN_ENABLE_STORED_PAYMENT_METHODS'] = $enable_stored_payment_methods;
 
         return $helper->generateForm($fields_form);
     }

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -246,10 +246,10 @@ class AdyenOfficial extends PaymentModule
     private function createDefaultConfigurations()
     {
         return $this->updateCronJobToken() &&
-            $this->setDefaultConfigurationForAutoCronjobRunner();
+            $this->setDefaultConfigurationForAutoCronjobRunner() &&
+            $this->setDefaultConfigurationForEnableStoredPaymentMethods() &&
+            $this->setDefaultConfigurationForPaymentDisplayCollapse();
     }
-
-    // TODO set default value 1 for ADYEN_ENABLE_STORED_PAYMENT_METHODS and 0 for ADYEN_PAYMENT_DISPLAY_COLLAPSE as soon as the PW-4366 is merged
 
     /**
      * @return bool
@@ -486,6 +486,22 @@ class AdyenOfficial extends PaymentModule
     public function setDefaultConfigurationForAutoCronjobRunner()
     {
         return Configuration::updateValue('ADYEN_AUTO_CRON_JOB_RUNNER', 0);
+    }
+
+    /**
+     * @return bool
+     */
+    public function setDefaultConfigurationForEnableStoredPaymentMethods()
+    {
+        return Configuration::updateValue('ADYEN_ENABLE_STORED_PAYMENT_METHODS', 1);
+    }
+
+    /**
+     * @return bool
+     */
+    public function setDefaultConfigurationForPaymentDisplayCollapse()
+    {
+        return Configuration::updateValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE', 0);
     }
 
     /**

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1349,7 +1349,8 @@ class AdyenOfficial extends PaymentModule
             'currencyIsoCode' => $currencyIsoCode,
             'totalAmountInMinorUnits' => $totalAmountInMinorUnits,
             'paymentMethodsConfigurations' => $paymentMethodsConfigurations,
-            'paymentMethodsWithPayButtonFromComponent' => $paymentMethodsWithPayButtonFromComponent
+            'paymentMethodsWithPayButtonFromComponent' => $paymentMethodsWithPayButtonFromComponent,
+            'enableStoredPaymentMethods' => Configuration::get('ADYEN_ENABLE_STORED_PAYMENT_METHODS') ? true : false
         );
     }
 

--- a/upgrade/upgrade-3.4.0.php
+++ b/upgrade/upgrade-3.4.0.php
@@ -39,5 +39,6 @@ if (!defined('_PS_VERSION_')) {
  */
 function upgrade_module_3_4_0(AdyenOfficial $module)
 {
-    return $module->setDefaultConfigurationForAutoCronjobRunner();
+    return $module->setDefaultConfigurationForAutoCronjobRunner() &&
+        $module->setDefaultConfigurationForEnableStoredPaymentMethods();
 }

--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -186,12 +186,14 @@ jQuery(document).ready(function() {
             };
         }
 
+        const enableStoreDetails = !!isUserLoggedIn && !!enableStoredPaymentMethods;
+
         var configuration = Object.assign(
             ADYEN_CHECKOUT_CONFIG,
             {
                 hasHolderName: true,
                 holderNameRequired: false,
-                enableStoreDetails: !!isUserLoggedIn,
+                enableStoreDetails: enableStoreDetails,
                 countryCode: countryCode,
                 data: {
                     billingAddress: componentBillingAddress,

--- a/views/templates/front/adyencheckout.tpl
+++ b/views/templates/front/adyencheckout.tpl
@@ -37,6 +37,7 @@
          data-currency-iso-code="{$currencyIsoCode|escape:'html':'UTF-8'}"
          data-total-amount-in-minor-units="{$totalAmountInMinorUnits|escape:'html':'UTF-8'}"
          data-payment-methods-with-pay-button-from-component="{$paymentMethodsWithPayButtonFromComponent|escape:'html':'UTF-8'}"
+         data-enable-stored-payment-methods="{$enableStoredPaymentMethods|escape:'html':'UTF-8'}"
 
             {if isset($selectedDeliveryAddressId)}
                 data-selected-delivery-address-id="{$selectedDeliveryAddressId|escape:'html':'UTF-8'}"
@@ -79,6 +80,7 @@
         var selectedInvoiceAddress = JSON.parse(adyenCheckoutConfiguration.selectedInvoiceAddress);
         var paymentMethodsConfigurations = JSON.parse(adyenCheckoutConfiguration.paymentMethodsConfigurations);
         var paymentMethodsWithPayButtonFromComponent = JSON.parse(adyenCheckoutConfiguration.paymentMethodsWithPayButtonFromComponent);
+        const enableStoredPaymentMethods = adyenCheckoutConfiguration.enableStoredPaymentMethods;
 
         var currencyIsoCode = adyenCheckoutConfiguration.currencyIsoCode;
         var totalAmountInMinorUnits = adyenCheckoutConfiguration.totalAmountInMinorUnits;


### PR DESCRIPTION
## Summary
New configuration to toggle stored payment methods is added to the admin configuration panel
In case it's enabled the customer (if logged in) can store and use stored payment methods
In case it's disabled no one click payment method can be stored or used
