### PR TITLE
[PW-4200] - Create download logs button

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -568,16 +568,33 @@ class AdyenOfficial extends PaymentModule
     public function installTab()
     {
         try {
-            $tab = new Tab();
-            $tab->id_parent = -1; // invisible tab
-            $tab->active = 1;
-            $tab->name = array();
+            $cronTab = new Tab();
+            $cronTab->id_parent = -1; // invisible tab
+            $cronTab->active = 1;
+            $cronTab->name = array();
             foreach (Language::getLanguages(true) as $lang) {
-                $tab->name[$lang['id_lang']] = 'Adyen Prestashop Cron';
+                $cronTab->name[$lang['id_lang']] = 'Adyen Prestashop Cron';
             }
-            $tab->class_name = 'AdminAdyenOfficialPrestashopCron';
-            $tab->module = $this->name;
-            return $tab->add();
+            $cronTab->class_name = 'AdminAdyenOfficialPrestashopCron';
+            $cronTab->module = $this->name;
+            $cronTabResult = $cronTab->add();
+
+            $logTab = new Tab();
+            if ($this->versionChecker->isPrestaShop16()) {
+                $logTab->id_parent = (int) Tab::getIdFromClassName('AdminTools');
+            } else {
+                $logTab->id_parent = (int) Tab::getIdFromClassName('AdminAdvancedParameters');
+            }
+            $logTab->active = 1;
+            $logTab->name = array();
+            foreach (Language::getLanguages() as $lang) {
+                $logTab->name[$lang['id_lang']] = 'Adyen Logs';
+            }
+            $logTab->class_name = 'AdminAdyenOfficialPrestashopLogFetcher';
+            $logTab->module = $this->name;
+            $logTabResult = $logTab->add();
+
+            return $cronTabResult && $logTabResult;
         } catch (PrestaShopDatabaseException $e) {
             return false;
         } catch (PrestaShopException $e) {

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -615,6 +615,9 @@ class AdyenOfficial extends PaymentModule
      */
     public function uninstallTabs()
     {
+        $cronTabDelete = false;
+        $logFetcherTabDelete = false;
+
         try {
             $cronTabId = (int)Tab::getIdFromClassName('AdminAdyenOfficialPrestashopCron');
             $logFetcherTabId = (int)Tab::getIdFromClassName('AdminAdyenOfficialPrestashopLogFetcher');

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -209,7 +209,7 @@ class AdyenOfficial extends PaymentModule
                 $this->registerHook('paymentReturn') &&
                 $this->registerHook('actionOrderSlipAdd') &&
                 $this->registerHook('actionFrontControllerSetMedia') &&
-                $this->installTab() &&
+                $this->installTabs() &&
                 $this->createDefaultConfigurations() &&
                 $this->createAdyenOrderStatuses() &&
                 $this->createAdyenDatabaseTables()
@@ -224,7 +224,7 @@ class AdyenOfficial extends PaymentModule
         // Version 1.7 or higher
         if (parent::install() &&
             $this->registerHook('displayPaymentTop') &&
-            $this->installTab() &&
+            $this->installTabs() &&
             $this->registerHook('actionFrontControllerSetMedia') &&
             $this->registerHook('paymentOptions') &&
             $this->registerHook('paymentReturn') &&
@@ -272,7 +272,7 @@ class AdyenOfficial extends PaymentModule
     public function uninstall()
     {
         return parent::uninstall() &&
-            $this->uninstallTab() &&
+            $this->uninstallTabs() &&
             $this->removeAdyenDatabaseTables() &&
             $this->removeConfigurationsFromDatabase();
     }
@@ -565,7 +565,7 @@ class AdyenOfficial extends PaymentModule
     /**
      * @return bool true if tab is installed
      */
-    public function installTab()
+    public function installTabs()
     {
         try {
             $cronTab = new Tab();
@@ -605,13 +605,19 @@ class AdyenOfficial extends PaymentModule
     /**
      * @return bool
      */
-    public function uninstallTab()
+    public function uninstallTabs()
     {
         try {
-            $id_tab = (int)Tab::getIdFromClassName('AdminAdyenOfficialPrestashopCron');
-            if ($id_tab) {
-                $tab = new Tab($id_tab);
-                return $tab->delete();
+            $cronTabId = (int)Tab::getIdFromClassName('AdminAdyenOfficialPrestashopCron');
+            $logFetcherTabId = (int)Tab::getIdFromClassName('AdminAdyenOfficialPrestashopLogFetcher');
+            if ($cronTabId) {
+                $cronTab = new Tab($cronTabId);
+                return $cronTab->delete();
+            }
+
+            if ($logFetcherTabId) {
+                $logFetcherTab = new Tab($logFetcherTabId);
+                return $logFetcherTab->delete();
             }
         } catch (PrestaShopDatabaseException $e) {
             return false;

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -596,8 +596,16 @@ class AdyenOfficial extends PaymentModule
 
             return $cronTabResult && $logTabResult;
         } catch (PrestaShopDatabaseException $e) {
+            $this->logger->error(
+                'Database exception thrown during tab installation: ' . $e->getMessage()
+            );
+
             return false;
         } catch (PrestaShopException $e) {
+            $this->logger->error(
+                'PrestaShop exception thrown during tab installation: ' . $e->getMessage()
+            );
+
             return false;
         }
     }
@@ -612,19 +620,28 @@ class AdyenOfficial extends PaymentModule
             $logFetcherTabId = (int)Tab::getIdFromClassName('AdminAdyenOfficialPrestashopLogFetcher');
             if ($cronTabId) {
                 $cronTab = new Tab($cronTabId);
-                return $cronTab->delete();
+                $cronTabDelete = $cronTab->delete();
             }
 
             if ($logFetcherTabId) {
                 $logFetcherTab = new Tab($logFetcherTabId);
-                return $logFetcherTab->delete();
+                $logFetcherTabDelete = $logFetcherTab->delete();
             }
+
+            return $cronTabDelete && $logFetcherTabDelete;
         } catch (PrestaShopDatabaseException $e) {
+            $this->logger->error(
+                'Database exception thrown during tab uninstall: ' . $e->getMessage()
+            );
+
             return false;
         } catch (PrestaShopException $e) {
+            $this->logger->error(
+                'PrestaShop exception thrown during tab uninstall: ' . $e->getMessage()
+            );
+
             return false;
         }
-        return false;
     }
 
 

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -27,10 +27,13 @@
 // phpcs:disable PSR1.Files.SideEffects, PSR1.Classes.ClassDeclaration
 
 use PrestaShop\PrestaShop\Adapter\CoreException;
+use PrestaShopBundle\Utils\ZipManager;
 
 
 class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminController
 {
+    /** @var ZipManager $zipManager */
+    private $zipManager;
 
     /**
      * AdminAdyenPrestashopCronController constructor.
@@ -39,17 +42,48 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
      */
     public function __construct()
     {
-        // Set variables
-        $this->display = 'view';
+        $this->zipManager = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('PrestaShopBundle\Utils\ZipManager');
 
+        // Required in order to automatically call the renderView function
+        $this->display = 'view';
         $this->bootstrap = true;
+        $this->toolbar_title[] = 'Adyen Logs';
         parent::__construct();
+
+        $this->zipAndDownload();
     }
 
     public function renderView()
     {
-        $tpl = $this->context->smarty->createTemplate(_PS_MODULE_DIR_ . $this->module->name.'/views/templates/admin/log-fetcher.tpl');
+        $tpl = $this->context->smarty->createTemplate(
+            _PS_MODULE_DIR_ . $this->module->name . '/views/templates/admin/log-fetcher.tpl'
+        );
 
         return $tpl->fetch();
+    }
+
+    /**
+     * Zip log files and download
+     */
+    public function zipAndDownload()
+    {
+        $dir = _PS_ROOT_DIR_ . '/var/logs/adyen';
+        $zip_file = Configuration::get('PS_SHOP_NAME') . '_' . date('Y-m-d') . '_' . 'Adyen_Logs.zip';
+
+        // Get real path for our folder
+        $rootPath = realpath($dir);
+
+        $this->zipManager->createArchive($zip_file, $rootPath);
+
+
+        header('Content-Description: File Transfer');
+        header('Content-Type: application/octet-stream');
+        header('Content-Disposition: attachment; filename='.basename($zip_file));
+        header('Content-Transfer-Encoding: binary');
+        header('Expires: 0');
+        header('Cache-Control: no-cache');
+        header('Pragma: public');
+        header('Content-Length: ' . filesize($zip_file));
+        readfile($zip_file);
     }
 }

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -26,41 +26,11 @@
 // Controllers, which breaks a PSR1 element.
 // phpcs:disable PSR1.Files.SideEffects, PSR1.Classes.ClassDeclaration
 
-use Adyen\PrestaShop\service\adapter\classes\ServiceLocator;
-use Adyen\PrestaShop\service\OrderPaymentService;
 use PrestaShop\PrestaShop\Adapter\CoreException;
-use Adyen\PrestaShop\exception\GenericLoggedException;
-use Adyen\PrestaShop\exception\MissingDataException;
-use Adyen\PrestaShop\service\adapter\classes\order\OrderAdapter;
-use Adyen\PrestaShop\service\adapter\classes\CustomerThreadAdapter;
-use Adyen\PrestaShop\service\notification\NotificationProcessor;
-use Adyen\PrestaShop\model\AdyenPaymentResponse;
-use Adyen\PrestaShop\model\AdyenNotification;
-use \Adyen\PrestaShop\service\Order as OrderService;
 
-require_once _PS_ROOT_DIR_ . '/modules/adyenofficial/vendor/autoload.php';
 
-class AdminAdyenOfficialPrestashopLogFetcherController extends \ModuleAdminController
+class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminController
 {
-    /**
-     * @var bool
-     */
-    public $ssl = true;
-
-    /**
-     * @var Adyen\PrestaShop\helper\Data
-     */
-    private $helperData;
-
-    /**
-     * @var Adyen\PrestaShop\service\Logger
-     */
-    private $logger;
-
-    /**
-     * @var Adyen\PrestaShop\infra\Crypto
-     */
-    private $crypto;
 
     /**
      * AdminAdyenPrestashopCronController constructor.
@@ -69,82 +39,17 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends \ModuleAdminContr
      */
     public function __construct()
     {
-        $this->helperData = ServiceLocator::get('Adyen\PrestaShop\helper\Data');
-        $this->logger = ServiceLocator::get('Adyen\PrestaShop\service\Logger');
-        $this->crypto = ServiceLocator::get('Adyen\PrestaShop\infra\Crypto');
+        // Set variables
+        $this->display = 'view';
 
-        $cronjobToken = '';
-
-        try {
-            $cronjobToken = $this->crypto->decrypt(\Configuration::get('ADYEN_CRONJOB_TOKEN'));
-        } catch (GenericLoggedException $e) {
-            $this->logger->error(
-                'For configuration "ADYEN_CRONJOB_TOKEN" an exception was thrown: ' . $e->getMessage()
-            );
-        } catch (MissingDataException $e) {
-            $this->logger->debug(
-                'The configuration "ADYEN_CRONJOB_TOKEN" has no value set, please add a secure token!'
-            );
-        }
-
-        if (\Tools::getValue('token') != $cronjobToken) {
-            die('Invalid token');
-        }
-
-        $this->context = \Context::getContext();
-
+        $this->bootstrap = true;
         parent::__construct();
-        $failedNotifications = $this->postProcess();
-        if (empty($failedNotifications)) {
-            $message = 'Cron job finished successfully';
-        } else {
-            $message = sprintf(
-                'An error occurred during the execution of the following notifications: %s',
-                implode(', ', $failedNotifications)
-            );
-        }
-
-        die($message);
     }
 
-    /**
-     * @return array
-     * @throws Exception
-     */
-    public function postProcess()
+    public function renderView()
     {
-        $failedNotifications = array();
-        $notificationProcessor = new NotificationProcessor(
-            $this->helperData,
-            \Db::getInstance(),
-            new OrderAdapter(),
-            new CustomerThreadAdapter(),
-            $this->logger,
-            \Context::getContext(),
-            new AdyenPaymentResponse(),
-            new OrderService(),
-            new \Adyen\Util\Currency(),
-            new OrderPaymentService()
-        );
+        $tpl = $this->context->smarty->createTemplate(_PS_MODULE_DIR_ . $this->module->name.'/views/templates/admin/log-fetcher.tpl');
 
-        $notificationModel = new AdyenNotification();
-
-        $unprocessedNotifications = $notificationModel->getUnprocessedNotifications();
-
-        foreach ($unprocessedNotifications as $unprocessedNotification) {
-            // update as processing
-            $notificationModel->updateNotificationAsProcessing($unprocessedNotification['entity_id']);
-
-            if ($notificationProcessor->processNotification($unprocessedNotification)) {
-                // processing is done
-                $notificationModel->updateNotificationAsDone($unprocessedNotification['entity_id']);
-            } else {
-                // processing had some error
-                $notificationModel->updateNotificationAsNew($unprocessedNotification['entity_id']);
-                $failedNotifications[] = $unprocessedNotification['entity_id'];
-            }
-        }
-
-        return $failedNotifications;
+        return $tpl->fetch();
     }
 }

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -71,13 +71,21 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         $this->toolbar_title[] = 'Adyen Logs';
         parent::__construct();
 
-        $this->createCurrentApplicationInfoFile();
-        $this->zipAndDownload();
-        die;
+        if ((string)Tools::getValue('download')) {
+            $this->createCurrentApplicationInfoFile();
+            $this->zipAndDownload();
+            die;
+        }
     }
 
     public function renderView()
     {
+        $smartyVariables = array(
+            'logo' => Media::getMediaPath(_PS_MODULE_DIR_ . $this->module->name . '/views/img/adyen.png'),
+            'downloadUrl' => '//' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . '&download=1'
+        );
+        $this->addCSS('modules/' . $this->module->name . '/views/css/adyen_admin.css', 'all');
+        $this->context->smarty->assign($smartyVariables);
         $tpl = $this->context->smarty->createTemplate(
             _PS_MODULE_DIR_ . $this->module->name . '/views/templates/admin/log-fetcher.tpl'
         );

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop plugin
+ *
+ * @author Adyen BV <support@adyen.com>
+ * @copyright (c) 2020 Adyen B.V.
+ * @license https://opensource.org/licenses/MIT MIT license
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+// This class is not in a namespace because of the way PrestaShop loads
+// Controllers, which breaks a PSR1 element.
+// phpcs:disable PSR1.Files.SideEffects, PSR1.Classes.ClassDeclaration
+
+use Adyen\PrestaShop\service\adapter\classes\ServiceLocator;
+use Adyen\PrestaShop\service\OrderPaymentService;
+use PrestaShop\PrestaShop\Adapter\CoreException;
+use Adyen\PrestaShop\exception\GenericLoggedException;
+use Adyen\PrestaShop\exception\MissingDataException;
+use Adyen\PrestaShop\service\adapter\classes\order\OrderAdapter;
+use Adyen\PrestaShop\service\adapter\classes\CustomerThreadAdapter;
+use Adyen\PrestaShop\service\notification\NotificationProcessor;
+use Adyen\PrestaShop\model\AdyenPaymentResponse;
+use Adyen\PrestaShop\model\AdyenNotification;
+use \Adyen\PrestaShop\service\Order as OrderService;
+
+require_once _PS_ROOT_DIR_ . '/modules/adyenofficial/vendor/autoload.php';
+
+class AdminAdyenOfficialPrestashopLogFetcherController extends \ModuleAdminController
+{
+    /**
+     * @var bool
+     */
+    public $ssl = true;
+
+    /**
+     * @var Adyen\PrestaShop\helper\Data
+     */
+    private $helperData;
+
+    /**
+     * @var Adyen\PrestaShop\service\Logger
+     */
+    private $logger;
+
+    /**
+     * @var Adyen\PrestaShop\infra\Crypto
+     */
+    private $crypto;
+
+    /**
+     * AdminAdyenPrestashopCronController constructor.
+     *
+     * @throws CoreException
+     */
+    public function __construct()
+    {
+        $this->helperData = ServiceLocator::get('Adyen\PrestaShop\helper\Data');
+        $this->logger = ServiceLocator::get('Adyen\PrestaShop\service\Logger');
+        $this->crypto = ServiceLocator::get('Adyen\PrestaShop\infra\Crypto');
+
+        $cronjobToken = '';
+
+        try {
+            $cronjobToken = $this->crypto->decrypt(\Configuration::get('ADYEN_CRONJOB_TOKEN'));
+        } catch (GenericLoggedException $e) {
+            $this->logger->error(
+                'For configuration "ADYEN_CRONJOB_TOKEN" an exception was thrown: ' . $e->getMessage()
+            );
+        } catch (MissingDataException $e) {
+            $this->logger->debug(
+                'The configuration "ADYEN_CRONJOB_TOKEN" has no value set, please add a secure token!'
+            );
+        }
+
+        if (\Tools::getValue('token') != $cronjobToken) {
+            die('Invalid token');
+        }
+
+        $this->context = \Context::getContext();
+
+        parent::__construct();
+        $failedNotifications = $this->postProcess();
+        if (empty($failedNotifications)) {
+            $message = 'Cron job finished successfully';
+        } else {
+            $message = sprintf(
+                'An error occurred during the execution of the following notifications: %s',
+                implode(', ', $failedNotifications)
+            );
+        }
+
+        die($message);
+    }
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    public function postProcess()
+    {
+        $failedNotifications = array();
+        $notificationProcessor = new NotificationProcessor(
+            $this->helperData,
+            \Db::getInstance(),
+            new OrderAdapter(),
+            new CustomerThreadAdapter(),
+            $this->logger,
+            \Context::getContext(),
+            new AdyenPaymentResponse(),
+            new OrderService(),
+            new \Adyen\Util\Currency(),
+            new OrderPaymentService()
+        );
+
+        $notificationModel = new AdyenNotification();
+
+        $unprocessedNotifications = $notificationModel->getUnprocessedNotifications();
+
+        foreach ($unprocessedNotifications as $unprocessedNotification) {
+            // update as processing
+            $notificationModel->updateNotificationAsProcessing($unprocessedNotification['entity_id']);
+
+            if ($notificationProcessor->processNotification($unprocessedNotification)) {
+                // processing is done
+                $notificationModel->updateNotificationAsDone($unprocessedNotification['entity_id']);
+            } else {
+                // processing had some error
+                $notificationModel->updateNotificationAsNew($unprocessedNotification['entity_id']);
+                $failedNotifications[] = $unprocessedNotification['entity_id'];
+            }
+        }
+
+        return $failedNotifications;
+    }
+}

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -73,6 +73,7 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
 
         $this->createCurrentApplicationInfoFile();
         $this->zipAndDownload();
+        die;
     }
 
     public function renderView()
@@ -160,8 +161,8 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
 
         $content = $adyenPaymentSource . $prestashopVersion . $environment . $this->getConfigurationValues();
 
-        $filePath = fopen($this->logsDirectory . "/applicationInfo","wb");
-        fwrite($filePath,$content);
+        $filePath = fopen($this->logsDirectory . "/applicationInfo", "wb");
+        fwrite($filePath, $content);
         fclose($filePath);
     }
 
@@ -221,25 +222,33 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
             Configuration::get('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER')
         );
 
-        $configs['notificationPass'] = sprintf(
-            "\nNotification password last 4: %s",
-            substr($this->crypto->decrypt(Configuration::get('ADYEN_NOTI_PASSWORD')), -4)
-        );
+        if (!empty(Configuration::get('ADYEN_NOTI_PASSWORD'))) {
+            $configs['notificationPass'] = sprintf(
+                "\nNotification password last 4: %s",
+                substr($this->crypto->decrypt(Configuration::get('ADYEN_NOTI_PASSWORD')), -4)
+            );
+        }
 
-        $configs['notificationHmac'] = sprintf(
-            "\nNotification HMAC last 4: %s",
-            substr($this->crypto->decrypt(Configuration::get('ADYEN_NOTI_HMAC')), -4)
-        );
+        if (!empty(Configuration::get('ADYEN_NOTI_HMAC'))) {
+            $configs['notificationHmac'] = sprintf(
+                "\nNotification HMAC last 4: %s",
+                substr($this->crypto->decrypt(Configuration::get('ADYEN_NOTI_HMAC')), -4)
+            );
+        }
 
-        $configs['apiKeyTest'] = sprintf(
-            "\nApi key test last 4: %s",
-            substr($this->crypto->decrypt(Configuration::get('ADYEN_APIKEY_TEST')), -4)
-        );
+        if (!empty(Configuration::get('ADYEN_APIKEY_TEST'))) {
+            $configs['apiKeyTest'] = sprintf(
+                "\nApi key test last 4: %s",
+                substr($this->crypto->decrypt(Configuration::get('ADYEN_APIKEY_TEST')), -4)
+            );
+        }
 
-        $configs['apiKeyLive'] = sprintf(
-            "\nApi key live last 4: %s",
-            substr($this->crypto->decrypt(Configuration::get('ADYEN_APIKEY_LIVE')), -4)
-        );
+        if (!empty(Configuration::get('ADYEN_APIKEY_LIVE'))) {
+            $configs['apiKeyLive'] = sprintf(
+                "\nApi key live last 4: %s",
+                substr($this->crypto->decrypt(Configuration::get('ADYEN_APIKEY_LIVE')), -4)
+            );
+        }
 
         foreach ($configs as $config) {
             $configValues .= $config;

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -267,7 +267,7 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
     }
 
     /**
-     * Get the url accessed when the button is clicked, to download the url
+     * Get the url accessed when the button is clicked, to download the zip file
      *
      * @return string
      */
@@ -276,6 +276,6 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         $adminUrl = Tools::getAdminUrl('admin-dev/index.php?controller=AdminAdyenOfficialPrestashopLogFetcher&token=');
         $token = Tools::getAdminTokenLite('AdminAdyenOfficialPrestashopLogFetcher');
 
-        return $adminUrl . $token . '&download=1';
+        return $adminUrl . $token;
     }
 }

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -16,7 +16,7 @@
  * Adyen PrestaShop plugin
  *
  * @author Adyen BV <support@adyen.com>
- * @copyright (c) 2020 Adyen B.V.
+ * @copyright (c) 2021 Adyen B.V.
  * @license https://opensource.org/licenses/MIT MIT license
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
@@ -65,12 +65,13 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
             $this->logsDirectory = _PS_ROOT_DIR_ . '/var/logs/adyen';
         }
 
-        // Required in order to automatically call the renderView function
+        // Required to automatically call the renderView function
         $this->display = 'view';
         $this->bootstrap = true;
         $this->toolbar_title[] = 'Adyen Logs';
         parent::__construct();
 
+        // Zip download is triggered when queryParameter contains the download string
         if ((string)Tools::getValue('download')) {
             $this->createCurrentApplicationInfoFile();
             $this->zipAndDownload();
@@ -78,16 +79,27 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         }
     }
 
+    /**
+     * Render the log-fetcher template
+     *
+     * @return false|string
+     * @throws SmartyException
+     */
     public function renderView()
     {
         $smartyVariables = array(
             'logo' => Media::getMediaPath(_PS_MODULE_DIR_ . $this->module->name . '/views/img/adyen.png'),
             'downloadUrl' => '//' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . '&download=1'
         );
-        $this->addCSS('modules/' . $this->module->name . '/views/css/adyen_admin.css', 'all');
         $this->context->smarty->assign($smartyVariables);
+        $this->addCSS('modules/' . $this->module->name . '/views/css/adyen_admin.css');
+
+        // Passing variables in this call required for 1.6
         $tpl = $this->context->smarty->createTemplate(
-            _PS_MODULE_DIR_ . $this->module->name . '/views/templates/admin/log-fetcher.tpl'
+            _PS_MODULE_DIR_ . $this->module->name . '/views/templates/admin/log-fetcher.tpl',
+            null,
+            null,
+            $smartyVariables
         );
 
         return $tpl->fetch();

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -175,7 +175,12 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
             $this->configuration->liveEndpointPrefix
         );
 
-        $content = $adyenPaymentSource . $prestashopVersion . $environment . $this->getConfigurationValues();
+        $time = sprintf(
+            "\nDate and time: %s",
+            date('Y-m-d H:i:s')
+        );
+
+        $content = $adyenPaymentSource . $prestashopVersion . $environment . $time . $this->getConfigurationValues();
 
         $filePath = fopen($this->logsDirectory . "/applicationInfo", "wb");
         fwrite($filePath, $content);

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -26,6 +26,9 @@
 // Controllers, which breaks a PSR1 element.
 // phpcs:disable PSR1.Files.SideEffects, PSR1.Classes.ClassDeclaration
 
+use Adyen\PrestaShop\exception\GenericLoggedException;
+use Adyen\PrestaShop\exception\MissingDataException;
+use Adyen\PrestaShop\service\adapter\classes\ServiceLocator;
 use PrestaShop\PrestaShop\Adapter\CoreException;
 use PrestaShopBundle\Utils\ZipManager;
 
@@ -35,6 +38,14 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
     /** @var ZipManager $zipManager */
     private $zipManager;
 
+    /** @var \Adyen\PrestaShop\service\adapter\classes\Configuration $configuration */
+    private $configuration;
+
+    /**
+     * @var Adyen\PrestaShop\infra\Crypto
+     */
+    private $crypto;
+
     /**
      * AdminAdyenPrestashopCronController constructor.
      *
@@ -42,7 +53,9 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
      */
     public function __construct()
     {
-        $this->zipManager = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('PrestaShopBundle\Utils\ZipManager');
+        $this->zipManager = ServiceLocator::get('PrestaShopBundle\Utils\ZipManager');
+        $this->configuration = ServiceLocator::get('Adyen\PrestaShop\service\adapter\classes\Configuration');
+        $this->crypto = ServiceLocator::get('Adyen\PrestaShop\infra\Crypto');
 
         // Required in order to automatically call the renderView function
         $this->display = 'view';
@@ -50,6 +63,7 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         $this->toolbar_title[] = 'Adyen Logs';
         parent::__construct();
 
+        $this->createCurrentApplicationInfoFile();
         $this->zipAndDownload();
     }
 
@@ -63,9 +77,9 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
     }
 
     /**
-     * Zip log files and download
+     * Zip all files in the adyen log directory and download
      */
-    public function zipAndDownload()
+    private function zipAndDownload()
     {
         $dir = _PS_ROOT_DIR_ . '/var/logs/adyen';
         $zip_file = Configuration::get('PS_SHOP_NAME') . '_' . date('Y-m-d') . '_' . 'Adyen_Logs.zip';
@@ -85,5 +99,84 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         header('Pragma: public');
         header('Content-Length: ' . filesize($zip_file));
         readfile($zip_file);
+    }
+
+    /**
+     * Create a text file with the current application info
+     */
+    private function createCurrentApplicationInfoFile()
+    {
+        $adyenPaymentSource = sprintf(
+            'Adyen module version: %s',
+            $this->configuration->moduleVersion
+        );
+
+        $prestashopVersion = sprintf("\nPrestashop version: %s", _PS_VERSION_);
+
+        if (!empty($this->configuration->integratorName)) {
+            $prestashopVersion .= sprintf(' with integrator: %s', $this->configuration->integratorName);
+        }
+
+        $environment = sprintf(
+            "\nEnvironment: %s, with live endpoint prefix: %s",
+            $this->configuration->adyenMode,
+            $this->configuration->liveEndpointPrefix
+        );
+
+        $content = $adyenPaymentSource . $prestashopVersion . $environment . $this->getConfigurationValues();
+
+        $filePath = fopen(_PS_ROOT_DIR_ . '/var/logs/adyen' . "/applicationInfo","wb");
+        fwrite($filePath,$content);
+        fclose($filePath);
+    }
+
+    /**
+     * Get all remaining config values
+     *
+     * @return string
+     * @throws GenericLoggedException
+     * @throws MissingDataException
+     */
+    private function getConfigurationValues()
+    {
+        $configValues = "\n\nConfiguration values: \n";
+        $configs['autoCronJobRunner'] = sprintf("\nAuto cronjob runner: %s", Configuration::get('ADYEN_AUTO_CRON_JOB_RUNNER'));
+        $configs['storedPaymentMethods'] = sprintf("\nStored payment methods: %s", Configuration::get('ADYEN_ENABLE_STORED_PAYMENT_METHODS'));
+        $configs['displayCollapse'] = sprintf("\nPayment display collapse: %s", Configuration::get('ADYEN_PAYMENT_DISPLAY_COLLAPSE'));
+        $configs['merchantAccount'] = sprintf("\nMerchant account: %s", Configuration::get('ADYEN_MERCHANT_ACCOUNT'));
+        $configs['mode'] = sprintf("\nMode: %s", Configuration::get('ADYEN_MODE'));
+        $configs['notificationUser'] = sprintf("\nNotification user: %s", Configuration::get('ADYEN_NOTI_USERNAME'));
+        $configs['clientKeyTest'] = sprintf("\nClient key test: %s", Configuration::get('ADYEN_CLIENTKEY_TEST'));
+        $configs['clientKeyLive'] = sprintf("\nClient key live: %s", Configuration::get('ADYEN_CLIENTKEY_LIVE'));
+        $configs['appleName'] = sprintf("\nApple pay merchant name: %s", Configuration::get('ADYEN_APPLE_PAY_MERCHANT_NAME'));
+        $configs['appleIdentifier'] = sprintf("\nApple pay merchant identifier: %s", Configuration::get('ADYEN_APPLE_PAY_MERCHANT_IDENTIFIER'));
+        $configs['googleGatewayMerchant'] = sprintf("\nGoogle pay merchant gateway id: %s", Configuration::get('ADYEN_APPLE_PAY_MERCHANT_NAME'));
+        $configs['googleIdentifier'] = sprintf("\nGoogle pay merchant identifier: %s", Configuration::get('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER'));
+
+        $configs['notificationPass'] = sprintf(
+            "\nNotification password last 4: %s",
+            substr($this->crypto->decrypt(Configuration::get('ADYEN_NOTI_PASSWORD')), -4)
+        );
+
+        $configs['notificationHmac'] = sprintf(
+            "\nNotification HMAC last 4: %s",
+            substr($this->crypto->decrypt(Configuration::get('ADYEN_NOTI_HMAC')), -4)
+        );
+
+        $configs['apiKeyTest'] = sprintf(
+            "\nApi key test last 4: %s",
+            substr($this->crypto->decrypt(Configuration::get('ADYEN_APIKEY_TEST')), -4)
+        );
+
+        $configs['apiKeyLive'] = sprintf(
+            "\nApi key live last 4: %s",
+            substr($this->crypto->decrypt(Configuration::get('ADYEN_APIKEY_LIVE')), -4)
+        );
+
+        foreach ($configs as $config) {
+            $configValues .= $config;
+        }
+
+        return $configValues;
     }
 }

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -115,13 +115,10 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         $rootPath = realpath($this->logsDirectory);
         $this->createArchive($zip_file, $rootPath);
 
-        header('Content-Description: File Transfer');
-        header('Content-Type: application/octet-stream');
-        header('Content-Disposition: attachment; filename='.basename($zip_file));
-        header('Content-Transfer-Encoding: binary');
+        header('Content-Type: application/zip');
+        header('Content-Disposition: attachment; filename=' . basename($zip_file));
         header('Expires: 0');
-        header('Cache-Control: no-cache');
-        header('Pragma: public');
+        header('Cache-Control: must-revalidate');
         header('Content-Length: ' . filesize($zip_file));
         readfile($zip_file);
     }

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -75,7 +75,7 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         if ((string)Tools::getValue('download')) {
             $this->createCurrentApplicationInfoFile();
             $this->zipAndDownload();
-            die;
+            exit;
         }
     }
 
@@ -242,22 +242,6 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
             "\nGoogle pay merchant identifier: %s",
             Configuration::get('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER')
         );
-
-        $notificationPass = Configuration::get('ADYEN_NOTI_PASSWORD');
-        if (!empty($notificationPass)) {
-            $configs['notificationPass'] = sprintf(
-                "\nNotification password last 4: %s",
-                substr($this->crypto->decrypt($notificationPass), -4)
-            );
-        }
-
-        $notificationHmac = Configuration::get('ADYEN_NOTI_HMAC');
-        if (!empty($notificationHmac)) {
-            $configs['notificationHmac'] = sprintf(
-                "\nNotification HMAC last 4: %s",
-                substr($this->crypto->decrypt($notificationHmac), -4)
-            );
-        }
 
         $apiKeyTest = Configuration::get('ADYEN_APIKEY_TEST');
         if (!empty($apiKeyTest)) {

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -74,7 +74,7 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         // Zip download is triggered when queryParameter contains the download string
         if ((string)Tools::getValue('download')) {
             $this->createCurrentApplicationInfoFile();
-            $this->zipAndDownload();
+            $this->zipAndDownload(Tools::getValue('include-all'));
             exit;
         }
     }
@@ -105,12 +105,17 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
     }
 
     /**
-     * Zip all files in the adyen log directory and download
+     * Zip all files in the adyen log directory and download. If includeAll is set, zip all logs
+     *
+     * @param $includeAll
      */
-    private function zipAndDownload()
+    private function zipAndDownload($includeAll)
     {
-        $zip_file = Configuration::get('PS_SHOP_NAME') . '_' . date('Y-m-d') . '_' . 'Adyen_Logs.zip';
+        if ($includeAll) {
+            $this->logsDirectory = substr($this->logsDirectory, 0, strrpos($this->logsDirectory, '/'));
+        }
 
+        $zip_file = Configuration::get('PS_SHOP_NAME') . '_' . date('Y-m-d') . '_' . 'Adyen_Logs.zip';
         // Get real path for our folder
         $rootPath = realpath($this->logsDirectory);
         $this->createArchive($zip_file, $rootPath);

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -60,9 +60,9 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         $this->crypto = ServiceLocator::get('Adyen\PrestaShop\infra\Crypto');
         $this->versionChecker = ServiceLocator::get('Adyen\PrestaShop\application\VersionChecker');
         if ($this->versionChecker->isPrestaShop16()) {
-            $this->logsDirectory = _PS_ROOT_DIR_ . '/log/adyen';
+            $this->logsDirectory = _PS_ROOT_DIR_ . '/log';
         } else {
-            $this->logsDirectory = _PS_ROOT_DIR_ . '/var/logs/adyen';
+            $this->logsDirectory = _PS_ROOT_DIR_ . '/var/logs';
         }
 
         // Required to automatically call the renderView function
@@ -105,14 +105,14 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
     }
 
     /**
-     * Zip all files in the adyen log directory and download. If includeAll is set, zip all logs
+     * Zip all log files. If includeAll is false, zip only the adyen log files
      *
      * @param $includeAll
      */
     private function zipAndDownload($includeAll)
     {
-        if ($includeAll) {
-            $this->logsDirectory = substr($this->logsDirectory, 0, strrpos($this->logsDirectory, '/'));
+        if (!$includeAll) {
+            $this->logsDirectory = $this->logsDirectory . '/adyen';
         }
 
         $zip_file = Configuration::get('PS_SHOP_NAME') . '_' . date('Y-m-d') . '_' . 'Adyen_Logs.zip';

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -89,7 +89,7 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
     {
         $smartyVariables = array(
             'logo' => Media::getMediaPath(_PS_MODULE_DIR_ . $this->module->name . '/views/img/adyen.png'),
-            'downloadUrl' => '//' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . '&download=1'
+            'downloadUrl' => $this->getDownloadUrl()
         );
         $this->addCSS('modules/' . $this->module->name . '/views/css/adyen_admin.css');
 
@@ -130,7 +130,7 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
      * @param $filename
      * @param $folder
      */
-    public function createArchive($filename, $folder)
+    private function createArchive($filename, $folder)
     {
         $zip = new ZipArchive();
 
@@ -264,5 +264,18 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
         }
 
         return $configValues;
+    }
+
+    /**
+     * Get the url accessed when the button is clicked, to download the url
+     *
+     * @return string
+     */
+    private function getDownloadUrl()
+    {
+        $adminUrl = Tools::getAdminUrl('admin-dev/index.php?controller=AdminAdyenOfficialPrestashopLogFetcher&token=');
+        $token = Tools::getAdminTokenLite('AdminAdyenOfficialPrestashopLogFetcher');
+
+        return $adminUrl . $token . '&download=1';
     }
 }

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -222,31 +222,35 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
             Configuration::get('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER')
         );
 
-        if (!empty(Configuration::get('ADYEN_NOTI_PASSWORD'))) {
+        $notificationPass = Configuration::get('ADYEN_NOTI_PASSWORD');
+        if (!empty($notificationPass)) {
             $configs['notificationPass'] = sprintf(
                 "\nNotification password last 4: %s",
-                substr($this->crypto->decrypt(Configuration::get('ADYEN_NOTI_PASSWORD')), -4)
+                substr($this->crypto->decrypt($notificationPass), -4)
             );
         }
 
-        if (!empty(Configuration::get('ADYEN_NOTI_HMAC'))) {
+        $notificationHmac = Configuration::get('ADYEN_NOTI_HMAC');
+        if (!empty($notificationHmac)) {
             $configs['notificationHmac'] = sprintf(
                 "\nNotification HMAC last 4: %s",
-                substr($this->crypto->decrypt(Configuration::get('ADYEN_NOTI_HMAC')), -4)
+                substr($this->crypto->decrypt($notificationHmac), -4)
             );
         }
 
-        if (!empty(Configuration::get('ADYEN_APIKEY_TEST'))) {
+        $apiKeyTest = Configuration::get('ADYEN_APIKEY_TEST');
+        if (!empty($apiKeyTest)) {
             $configs['apiKeyTest'] = sprintf(
                 "\nApi key test last 4: %s",
-                substr($this->crypto->decrypt(Configuration::get('ADYEN_APIKEY_TEST')), -4)
+                substr($this->crypto->decrypt($apiKeyTest), -4)
             );
         }
 
-        if (!empty(Configuration::get('ADYEN_APIKEY_LIVE'))) {
+        $apiKeyLive = Configuration::get('ADYEN_APIKEY_LIVE');
+        if (!empty($apiKeyLive)) {
             $configs['apiKeyLive'] = sprintf(
                 "\nApi key live last 4: %s",
-                substr($this->crypto->decrypt(Configuration::get('ADYEN_APIKEY_LIVE')), -4)
+                substr($this->crypto->decrypt($apiKeyLive), -4)
             );
         }
 

--- a/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopLogFetcherController.php
@@ -91,10 +91,9 @@ class AdminAdyenOfficialPrestashopLogFetcherController extends ModuleAdminContro
             'logo' => Media::getMediaPath(_PS_MODULE_DIR_ . $this->module->name . '/views/img/adyen.png'),
             'downloadUrl' => '//' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . '&download=1'
         );
-        $this->context->smarty->assign($smartyVariables);
         $this->addCSS('modules/' . $this->module->name . '/views/css/adyen_admin.css');
 
-        // Passing variables in this call required for 1.6
+        // Passing variables in this call (instead of assign()) required for 1.6
         $tpl = $this->context->smarty->createTemplate(
             _PS_MODULE_DIR_ . $this->module->name . '/views/templates/admin/log-fetcher.tpl',
             null,

--- a/views/css/adyen_admin.css
+++ b/views/css/adyen_admin.css
@@ -28,11 +28,10 @@
 .log-container {
     background-color: white;
     text-align: center;
-    padding: 20px;
+    padding: 40px;
 }
 
 .log-container .logo {
-    margin: auto;
     margin-bottom: 20px;
 }
 

--- a/views/css/adyen_admin.css
+++ b/views/css/adyen_admin.css
@@ -21,6 +21,37 @@
  * See the LICENSE file for more info.
  */
 
-.form-group input.adyen-input-green{
+.form-group input.adyen-input-green {
     border-color: rgba(20,255,20);
+}
+
+.log-container {
+    background-color: white;
+    text-align: center;
+}
+
+.log-container .logo {
+    margin: auto;
+    max-width: 30%;
+}
+
+.adyen .btn-outline-primary {
+    color: #25b9d7;
+    background-color: transparent;
+    background-image: none;
+    border-color: #25b9d7;
+}
+
+.adyen .btn-outline-primary:hover {
+    color: #fff;
+    background-color: #3ed2f0;
+    border-color: #3ed2f0;
+}
+
+.adyen .btn {
+    border-width: 1px;
+    font-weight: 600;
+    border-radius: .063rem;
+    white-space: nowrap;
+    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }

--- a/views/css/adyen_admin.css
+++ b/views/css/adyen_admin.css
@@ -28,11 +28,12 @@
 .log-container {
     background-color: white;
     text-align: center;
+    padding: 20px;
 }
 
 .log-container .logo {
     margin: auto;
-    max-width: 30%;
+    margin-bottom: 20px;
 }
 
 .adyen .btn-outline-primary {

--- a/views/templates/admin/log-fetcher.tpl
+++ b/views/templates/admin/log-fetcher.tpl
@@ -1,11 +1,34 @@
+{*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop plugin
+ *
+ * @author Adyen BV <support@adyen.com>
+ * @copyright (c) 2021 Adyen B.V.
+ * @license https://opensource.org/licenses/MIT MIT license
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *}
 <div class="container">
     <div class="row">
-        <div class="col-lg-12">
+        <div class="col-lg-4 col-lg-offset-4">
             <div class="log-container adyen">
-            <img class="img-responsive logo" src="{$logo|escape:'html':'UTF-8'}">
-                <a href="{$downloadUrl}" class="btn btn-primary-reverse btn-outline-primary">
-                    Download Logs
-                </a>
+                <img class="img-responsive logo" src="{$logo|escape:'html':'UTF-8'}" alt="logo">
+                <p>
+                    Download all adyen related log files. For more information, checkout <a target="_blank" href="https://docs.adyen.com/plugins/prestashop#finding-the-logs">our docs</a>.
+                </p>
+                <a href="{$downloadUrl}" class="btn btn-primary-reverse btn-outline-primary">Download Logs</a>
             </div>
         </div>
     </div>

--- a/views/templates/admin/log-fetcher.tpl
+++ b/views/templates/admin/log-fetcher.tpl
@@ -26,7 +26,7 @@
             <div class="log-container adyen">
                 <img class="img-responsive logo" src="{$logo|escape:'html':'UTF-8'}" alt="logo">
                 <p>
-                    Download all adyen related log files and optionally include other prestashop logs. For more information, checkout <a target="_blank" href="https://docs.adyen.com/plugins/prestashop#finding-the-logs">our docs</a>.
+                    Download all Adyen-related log files and optionally include other Prestashop logs. For more information, check out <a target="_blank" href="https://docs.adyen.com/plugins/prestashop#finding-the-logs">our docs</a>.
                 </p>
                 <form id="downloadForm" action="{$downloadUrl}" method="POST">
                     <div class="checkbox">

--- a/views/templates/admin/log-fetcher.tpl
+++ b/views/templates/admin/log-fetcher.tpl
@@ -1,1 +1,12 @@
-HELLOOOOOOOO!!
+<div class="container">
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="log-container adyen">
+            <img class="img-responsive logo" src="{$logo|escape:'html':'UTF-8'}">
+                <a href="{$downloadUrl}" class="btn btn-primary-reverse btn-outline-primary">
+                    Download Logs
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/views/templates/admin/log-fetcher.tpl
+++ b/views/templates/admin/log-fetcher.tpl
@@ -22,7 +22,7 @@
  *}
 <div class="container">
     <div class="row">
-        <div class="col-lg-4 col-lg-offset-4">
+        <div class="col-lg-5 col-lg-offset-3">
             <div class="log-container adyen">
                 <img class="img-responsive logo" src="{$logo|escape:'html':'UTF-8'}" alt="logo">
                 <p>

--- a/views/templates/admin/log-fetcher.tpl
+++ b/views/templates/admin/log-fetcher.tpl
@@ -26,9 +26,14 @@
             <div class="log-container adyen">
                 <img class="img-responsive logo" src="{$logo|escape:'html':'UTF-8'}" alt="logo">
                 <p>
-                    Download all adyen related log files. For more information, checkout <a target="_blank" href="https://docs.adyen.com/plugins/prestashop#finding-the-logs">our docs</a>.
+                    Download all adyen related log files and optionally include other prestashop logs. For more information, checkout <a target="_blank" href="https://docs.adyen.com/plugins/prestashop#finding-the-logs">our docs</a>.
                 </p>
                 <form id="downloadForm" action="{$downloadUrl}" method="POST">
+                    <div class="checkbox">
+                        <label>
+                            <input name="include-all" type="checkbox">Include all log files
+                        </label>
+                    </div>
                     <input type="hidden" name="download" value="1">
                     <button type="submit" class="btn btn-primary-reverse btn-outline-primary">Download</button>
                 </form>

--- a/views/templates/admin/log-fetcher.tpl
+++ b/views/templates/admin/log-fetcher.tpl
@@ -28,7 +28,10 @@
                 <p>
                     Download all adyen related log files. For more information, checkout <a target="_blank" href="https://docs.adyen.com/plugins/prestashop#finding-the-logs">our docs</a>.
                 </p>
-                <a href="{$downloadUrl}" class="btn btn-primary-reverse btn-outline-primary">Download</a>
+                <form id="downloadForm" action="{$downloadUrl}" method="POST">
+                    <input type="hidden" name="download" value="1">
+                    <button type="submit" class="btn btn-primary-reverse btn-outline-primary">Download</button>
+                </form>
             </div>
         </div>
     </div>

--- a/views/templates/admin/log-fetcher.tpl
+++ b/views/templates/admin/log-fetcher.tpl
@@ -22,13 +22,13 @@
  *}
 <div class="container">
     <div class="row">
-        <div class="col-lg-5 col-lg-offset-3">
+        <div class="col-lg-4 col-lg-offset-4">
             <div class="log-container adyen">
                 <img class="img-responsive logo" src="{$logo|escape:'html':'UTF-8'}" alt="logo">
                 <p>
                     Download all adyen related log files. For more information, checkout <a target="_blank" href="https://docs.adyen.com/plugins/prestashop#finding-the-logs">our docs</a>.
                 </p>
-                <a href="{$downloadUrl}" class="btn btn-primary-reverse btn-outline-primary">Download Logs</a>
+                <a href="{$downloadUrl}" class="btn btn-primary-reverse btn-outline-primary">Download</a>
             </div>
         </div>
     </div>

--- a/views/templates/admin/log-fetcher.tpl
+++ b/views/templates/admin/log-fetcher.tpl
@@ -1,0 +1,1 @@
+HELLOOOOOOOO!!


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We see it as a huge scaling blocker, especially with smaller merchants, that they have no technical knowledge and technical functionality such as retrieving the log files. This ends up taking quite some time for them. (No server access, no developer, hosting provider not providing sftp etc)

Beside showing the critical errors in the prestashop logs table we should provide them a tool to zip and download all the log files (maybe also a txt with some useful information - plugin version, prestashop version, time etc)

**Steps**:
1. Create a new controller
1. Add this new functionality as a tab, as shown here
1. When this controller is accessed the logs should be downloaded automatically

## Tested scenarios
Download logs on 1.6
Download logs on 1.7
