### PR TITLE
[PW-4199] - Use prestsahop logs page for easier log access

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -958,7 +958,7 @@ class AdyenOfficial extends PaymentModule
                 'For configuration "ADYEN_APIKEY_LIVE" an exception was thrown: ' . $e->getMessage()
             );
         } catch (\Adyen\PrestaShop\exception\MissingDataException $e) {
-            $this->logger->error('The configuration "ADYEN_APIKEY_LIVE" has no value set.');
+            $this->logger->warning('The configuration "ADYEN_APIKEY_LIVE" has no value set.');
         }
 
         $apiKeyLiveLastDigits = Tools::substr($apiKeyLive, -4);

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -216,7 +216,7 @@ class AdyenOfficial extends PaymentModule
             ) {
                 return true;
             } else {
-                $this->logger->debug('Adyen module: installation failed!');
+                $this->logger->critical('Adyen module: installation failed!');
                 return false;
             }
         }
@@ -235,7 +235,7 @@ class AdyenOfficial extends PaymentModule
         ) {
             return true;
         } else {
-            $this->logger->debug('Adyen module: installation failed!');
+            $this->logger->critical('Adyen module: installation failed!');
             return false;
         }
     }
@@ -290,7 +290,7 @@ class AdyenOfficial extends PaymentModule
             $this->updateCronJobToken()) {
             return true;
         } else {
-            $this->logger->debug('Adyen module: reset failed!');
+            $this->logger->error('Adyen module: reset failed!');
             return false;
         }
     }
@@ -554,7 +554,7 @@ class AdyenOfficial extends PaymentModule
 
         foreach ($adyenConfigurationNames as $adyenConfigurationName) {
             if (!Configuration::deleteByName($adyenConfigurationName)) {
-                $this->logger->debug("Configuration couldn't be deleted by name: " . $adyenConfigurationName);
+                $this->logger->warning("Configuration couldn't be deleted by name: " . $adyenConfigurationName);
                 $result = false;
             }
         }
@@ -824,7 +824,7 @@ class AdyenOfficial extends PaymentModule
                 'For configuration "ADYEN_NOTI_PASSWORD" an exception was thrown: ' . $e->getMessage()
             );
         } catch (\Adyen\PrestaShop\exception\MissingDataException $e) {
-            $this->logger->debug(
+            $this->logger->error(
                 'The configuration "ADYEN_NOTI_PASSWORD" has no value set, please add the notification password!'
             );
         }
@@ -849,7 +849,7 @@ class AdyenOfficial extends PaymentModule
         } catch (\Adyen\PrestaShop\exception\GenericLoggedException $e) {
             $this->logger->error('For configuration "ADYEN_NOTI_HMAC" an exception was thrown: ' . $e->getMessage());
         } catch (\Adyen\PrestaShop\exception\MissingDataException $e) {
-            $this->logger->debug('The configuration "ADYEN_NOTI_HMAC" has no value set, please add the HMAC key!');
+            $this->logger->error('The configuration "ADYEN_NOTI_HMAC" has no value set, please add the HMAC key!');
         }
 
         $fields_form[0]['form']['input'][] = array(
@@ -874,7 +874,7 @@ class AdyenOfficial extends PaymentModule
                 'For configuration "ADYEN_CRONJOB_TOKEN" an exception was thrown: ' . $e->getMessage()
             );
         } catch (\Adyen\PrestaShop\exception\MissingDataException $e) {
-            $this->logger->debug(
+            $this->logger->warning(
                 'The configuration "ADYEN_CRONJOB_TOKEN" has no value set, please add a secure token!'
             );
         }
@@ -931,7 +931,7 @@ class AdyenOfficial extends PaymentModule
                 'For configuration "ADYEN_APIKEY_TEST" an exception was thrown: ' . $e->getMessage()
             );
         } catch (\Adyen\PrestaShop\exception\MissingDataException $e) {
-            $this->logger->debug('The configuration "ADYEN_APIKEY_TEST" has no value set.');
+            $this->logger->warning('The configuration "ADYEN_APIKEY_TEST" has no value set.');
         }
 
         $apiKeyTestLastDigits = Tools::substr($apiKeyTest, -4);
@@ -958,7 +958,7 @@ class AdyenOfficial extends PaymentModule
                 'For configuration "ADYEN_APIKEY_LIVE" an exception was thrown: ' . $e->getMessage()
             );
         } catch (\Adyen\PrestaShop\exception\MissingDataException $e) {
-            $this->logger->debug('The configuration "ADYEN_APIKEY_LIVE" has no value set.');
+            $this->logger->error('The configuration "ADYEN_APIKEY_LIVE" has no value set.');
         }
 
         $apiKeyLiveLastDigits = Tools::substr($apiKeyLive, -4);

--- a/service/Client.php
+++ b/service/Client.php
@@ -57,7 +57,7 @@ class Client extends \Adyen\Client
         } catch (GenericLoggedException $e) {
             $logger->error('For configuration "ADYEN_CRONJOB_TOKEN" an exception was thrown: ' . $e->getMessage());
         } catch (MissingDataException $e) {
-            $logger->debug('The API key configuration value is missing');
+            $logger->error('The API key configuration value is missing');
         }
 
         $this->setXApiKey($apiKey);

--- a/service/Logger.php
+++ b/service/Logger.php
@@ -97,6 +97,19 @@ class Logger extends \Monolog\Logger
     );
 
     /**
+     * Levels which should also be logged via PrestaShop, mapped to their PrestaShop severity
+     *
+     * @var array
+     */
+    protected static $prestashopLoggable = array(
+        self::EMERGENCY => 4,
+        self::CRITICAL => 4,
+        self::ERROR => 3,
+        self::WARNING => 2,
+        self::ADYEN_NOTIFICATION => 3
+    );
+
+    /**
      * @var VersionChecker
      */
     private $versionChecker;
@@ -202,6 +215,10 @@ class Logger extends \Monolog\Logger
     public function addRecord($level, $message, array $context = array())
     {
         $context['is_exception'] = $message instanceof \Exception;
+        if (array_key_exists($level, self::$prestashopLoggable)) {
+            \PrestaShopLogger::addLog($message, self::$prestashopLoggable[$level]);
+        }
+
         return parent::addRecord($level, $message, $context);
     }
 

--- a/service/Logger.php
+++ b/service/Logger.php
@@ -106,7 +106,6 @@ class Logger extends \Monolog\Logger
         self::CRITICAL => 4,
         self::ERROR => 3,
         self::WARNING => 2,
-        self::ADYEN_NOTIFICATION => 3
     );
 
     /**
@@ -205,7 +204,7 @@ class Logger extends \Monolog\Logger
     }
 
     /**
-     * Adds a log record.
+     * Adds a log record and depending on the level, also add it to the prestashop logs
      *
      * @param integer $level The logging level
      * @param string $message The log message
@@ -216,7 +215,14 @@ class Logger extends \Monolog\Logger
     {
         $context['is_exception'] = $message instanceof \Exception;
         if (array_key_exists($level, self::$prestashopLoggable)) {
-            \PrestaShopLogger::addLog($message, self::$prestashopLoggable[$level]);
+            \PrestaShopLogger::addLog(
+                $message,
+                self::$prestashopLoggable[$level],
+                null,
+                null,
+                null,
+                true
+            );
         }
 
         return parent::addRecord($level, $message, $context);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We should log certain logs (depending on severity) using the prestashop functionality so that our merchants could get a better understanding about what's happening in the plugin when accessing the prestashop logs page. Only log the errors, warnings and major issues. Informative ones can still be just stored in the log files. `PrestaShopLoggerCore::addLog` function can be used to add logs to this page.

## Tested scenarios
* Error message logged
* Warning message logged
