### PR TITLE
[PW-4635] - One-page checkout issue on 1.6 

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -229,7 +229,8 @@ class AdyenOfficial extends PaymentModule
                 'displayPaymentEU',
                 'displayPaymentReturn',
                 'actionOrderSlipAdd',
-                'actionFrontControllerSetMedia'
+                'actionFrontControllerSetMedia',
+                'displayCustomerAccountForm'
             ),
             '1.7' => array(
                 'displayPaymentTop',
@@ -274,6 +275,7 @@ class AdyenOfficial extends PaymentModule
                 $this->registerHook('paymentReturn') &&
                 $this->registerHook('actionOrderSlipAdd') &&
                 $this->registerHook('actionFrontControllerSetMedia') &&
+                $this->registerHook('displayCustomerAccountForm') &&
                 $this->installTabs() &&
                 $this->createDefaultConfigurations() &&
                 $this->createAdyenOrderStatuses() &&
@@ -1695,6 +1697,22 @@ class AdyenOfficial extends PaymentModule
                 . PHP_EOL . $e->getMessage()
             );
             return false;
+        }
+    }
+
+    /**
+     * Hook only executed on 1.6
+     *
+     * @param $params
+     * @throws Exception
+     */
+    public function hookDisplayCustomerAccountForm($params)
+    {
+        /** @var int $checkoutType */
+        $onePageCheckout =  Configuration::get('PS_ORDER_PROCESS_TYPE');
+        $guestCheckoutEnabled = Configuration::get('PS_GUEST_CHECKOUT_ENABLED');
+        if ($this->context->controller instanceof \OrderOpcController && $onePageCheckout && $guestCheckoutEnabled) {
+            return $this->hookDisplayPaymentTop();
         }
     }
 

--- a/helper/Data.php
+++ b/helper/Data.php
@@ -161,7 +161,7 @@ class Data
         );
 
         // If customer was created, but is a guest, do not send shopperReference
-        if (!\Validate::isLoadedObject($customer) && !$customer->isGuest()) {
+        if (\Validate::isLoadedObject($customer) && !$customer->isGuest()) {
             $shopperReference = str_pad($cart->id_customer, 3, '0', STR_PAD_LEFT);
             $adyenFields['shopperReference'] = $shopperReference;
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
On 1.6, if the merchant enables quick (one-page) checkout, the js in the checkout-component-renderer.js file is not executed at all.

The `ADYEN_CHECKOUT_CONFIG` is required for the **checkout-component-renderer** to function. Currently, this is set when the `hookDisplayPaymentTop` action is called.
However if one-page checkout is enabled, once the checkout page is loaded, `hookDisplayPaymentTop` is not executed, which implies that the `window.ADYEN_CHECKOUT_CONFIG` in the **checkout-component-renderer** will be set to null and so it will return without executing this js file.

Once the user fills in his guest checkout details and chooses the carrier, the payment options will be loaded, at which point the `hookDisplayPaymentTop` will be executed. However, since we do not call the **checkout-component-renderer** again (it uses `jQuery(document).ready()`), this file is not re-executed and so the functionality is unusable.

If the user refreshes, the guest user info is included in the session and the payment section of the checkout is displayed on page load. Hence, the `hookDisplayPaymentTop` will be executed and the **checkout-component-renderer** will be successfully loaded.

## Tested scenarios
Payment on 1.6 w/one-page checkout
Payment on 1.6 w/default checkout
Payment on 1.7
E2E tests
