### PR TITLE
[PW-4734] - 1.6 - Set cart product quantity when cart gets cloned 

### DIFF
--- a/service/Cart.php
+++ b/service/Cart.php
@@ -65,6 +65,7 @@ class Cart
         }
 
         // Field does not exist in prestashop 16
+        // Else set the cart qties manually to ensure consistency with layout header
         if (!$isPrestashop16) {
             // Get the checkout_session_data field of the previous cart
             $checkoutSessionData = \Db::getInstance()->getValue(
@@ -76,16 +77,20 @@ class Cart
                 'UPDATE ' . _DB_PREFIX_ . 'cart SET checkout_session_data = "' . pSQL($checkoutSessionData) . '"
         WHERE id_cart = ' . (int)$newCartId
             );
+        } else {
+            $context->smarty->assign('cart_qties', $context->cart->nbProducts());
         }
 
         // to map the new cart with the customer
         $context->cart->id_customer = $old_cart_customer_id;
         $context->cart->id_guest = $cart->id_guest;
+
         // to save the new cart
         $context->cart->save();
         if ($context->cart->id) {
             $context->cookie->id_cart = (int)$context->cart->id;
             $context->cookie->write();
         }
+
     }
 }

--- a/service/Cart.php
+++ b/service/Cart.php
@@ -91,6 +91,5 @@ class Cart
             $context->cookie->id_cart = (int)$context->cart->id;
             $context->cookie->write();
         }
-
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
On 1.6, the cart quantity in the header (shown in attached image) is set as a smarty variable in the PrestaShop `FrontController::init` function, by calling `(int)$cart->nbProducts()` on the context cart. However in this particular case, after a redirection which was failed/cancelled, the context cart is re-created only in the adyen front controller (by calling the the `cloneCart` function).

Hence on the first page load after a failed payment, the cart quantity in the prestashop controller will be set to 0, since the proper cart is created later in the flow, in the adyen controller. So the interface will show an empty cart, even though in reality the cart is not empty. After a refresh, the interface successfully loads the number of items in the cart. 

To solve this issue, we should set the `cart_qties` smarty variable when cloning the cart, on 1.6.

**Steps:**
1. Attempt a redirection payment
2. Payment failed/cancelled
3. Cart interface shows (empty)
4. Cart interface shows correct product amount after refresh

## Tested scenarios
3DS1 (Redirect) cancelled payment
3DS1 (Redirect) successful payment

![Screen Shot 2021-05-25 at 3 41 52 PM](https://user-images.githubusercontent.com/11156828/119523315-f2152b00-bd7c-11eb-8fd0-41517c78636d.png)

