### PR TITLE
[PW-4781] - Set addresses when cloning cart

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -235,7 +235,7 @@ class AdyenOfficial extends PaymentModule
                 'displayPaymentTop',
                 'actionFrontControllerSetMedia',
                 'paymentOptions',
-                'displayPaymentReturn',
+                'paymentReturn',
                 'actionOrderSlipAdd',
                 'actionEmailSendBefore'
             )

--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -394,7 +394,7 @@ abstract class FrontController extends \ModuleFrontController
                 $this->adyenPaymentResponseModel->deletePaymentResponseByCartId($cart->id);
 
                 // In case of refused payment there is no order created and the cart needs to be cloned and reinitiated
-                $this->cartService->cloneCurrentCart($this->context, $cart);
+                $this->cartService->cloneCurrentCart($this->context, $cart, $this->versionChecker->isPrestaShop16());
 
                 $this->logger->error(
                     "There was an error with the payment method. id:  " . $cart->id .

--- a/service/Cart.php
+++ b/service/Cart.php
@@ -39,12 +39,16 @@ class Cart
         $old_cart_secure_key = $cart->secure_key;
         // To save the customer id of current cart id and reassign the same to new cart
         $old_cart_customer_id = (int)$cart->id_customer;
+        $old_delivery_address_id = $cart->id_address_delivery;
+        $old_invoice_address_id = $cart->id_address_invoice;
 
         // To fetch the current cart products
         $cart_products = $cart->getProducts();
         // Creating new cart object
         $context->cart = new \Cart();
         $context->cart->id_lang = $context->language->id;
+        $context->cart->id_address_delivery = $old_delivery_address_id;
+        $context->cart->id_address_invoice = $old_invoice_address_id;
 
         $context->cart->id_currency = $context->currency->id;
         $context->cart->secure_key = $old_cart_secure_key;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently, in the `Cart::cloneCart` function, we do not set the `cart->id_address_delivery` and the `cart->id_invoice_delivery`.

In some cases, when a failed transaction is redirected and if there are multiple addresses, these 2 address fields will not be correctly set and hence the user will have to restart checkout from the address page, with no info regarding the failed payment. If the customer only has a single address available, this is not an issue.

Hence we need to set these 2 fields when cloning the cart, so the customer is redirected back to the payments page.

**Steps:**
1. Set the `cart->id_address_delivery` and the `cart->id_invoice_delivery` fields in the `Cart::cloneCart` function.

## Tested scenarios
E2E tests
