### PR TITLE
[PW-4635] - One-page checkout issue on 1.6

### DIFF
--- a/views/js/checkout-component-renderer.js
+++ b/views/js/checkout-component-renderer.js
@@ -22,60 +22,26 @@
  */
 
 jQuery(document).ready(function() {
+
+    // Version will be undefined on 1.6 on page load, if one-page checkout is enabled
+    if (typeof IS_PRESTA_SHOP_16 === 'undefined' || IS_PRESTA_SHOP_16) {
+        setupObserver16();
+    }
+
+    const prestaShopPlaceOrderButton = $('#payment-confirmation button');
+    var placeOrderInProgress = false;
+    var componentButtonPaymentMethods;
+
     if (!window.ADYEN_CHECKOUT_CONFIG) {
         return;
     }
 
-    const componentButtonPaymentMethods = paymentMethodsWithPayButtonFromComponent;
-    const prestaShopPlaceOrderButton = $('#payment-confirmation button');
-    var placeOrderInProgress = false;
+    // Set which methods have their own button
+    componentButtonPaymentMethods = paymentMethodsWithPayButtonFromComponent;
 
     renderPaymentMethods();
 
-    // For prestashop 1.6 one page checkout retrieves the payment methods via
-    // ajax when the terms and conditions checkbox is clicked, so to render the
-    // components we call the renderPaymentMethods when the HOOK_PAYMENT childs
-    // are being added or removed
-    if (typeof IS_PRESTA_SHOP_16 !== 'undefined' && IS_PRESTA_SHOP_16) {
-        // Select the node that will be observed for mutations
-        const targetNode = document.getElementById('HOOK_PAYMENT');
-
-        // In case the targetNode does not exist return early
-        if (null === targetNode) {
-            return;
-        }
-
-        // Options for the observer (which mutations to observe)
-        const config = {attributes: true, childList: true, subtree: false};
-
-        // Callback function to execute when mutations are observed
-        const callback = function(mutationsList, observer) {
-            // Use traditional 'for loops' for IE 11
-            for (const mutation of mutationsList) {
-                if (mutation.type === 'childList') {
-                    // The children are being changed so disconnet the observer
-                    // at first to avoid infinite loop
-                    observer.disconnect();
-                    // Render the adyen checkout components
-                    renderPaymentMethods();
-                }
-            }
-
-            // Connect the observer again in case the checkbox is clicked
-            // multiple times
-            observer.observe(targetNode, config);
-        };
-
-        // Create an observer instance linked to the callback function
-        const observer = new MutationObserver(callback);
-
-        // Start observing the target node for configured mutations
-        try {
-            observer.observe(targetNode, config);
-        } catch (e) {
-            // observer exception
-        }
-    } else {
+    if (!IS_PRESTA_SHOP_16) {
         const queryParams = new URLSearchParams(window.location.search);
         if (queryParams.has('message')) {
             showRedirectErrorMessage(queryParams.get('message'));
@@ -648,5 +614,54 @@ jQuery(document).ready(function() {
 
     function isPlaceOrderInProgress() {
         return placeOrderInProgress;
+    }
+
+    // For prestashop 1.6 one page checkout retrieves the payment methods via ajax when the t&c checkbox is clicked,
+    // so to render the components we call the renderPaymentMethods when the HOOK_PAYMENT childs are being added or
+    // removed
+    function setupObserver16() {
+        // Select the node that will be observed for mutations
+        const targetNode = document.getElementById('HOOK_PAYMENT');
+
+        // In case the targetNode does not exist return early
+        if (null === targetNode) {
+            return;
+        }
+
+        // Options for the observer (which mutations to observe)
+        const config = {attributes: true, childList: true, subtree: false};
+
+        // Callback function to execute when mutations are observed
+        const callback = function(mutationsList, observer) {
+            // extra check to make sure that we are on 1.6
+            if (IS_PRESTA_SHOP_16) {
+                // Set which methods have their own button
+                componentButtonPaymentMethods = paymentMethodsWithPayButtonFromComponent;
+                // Use traditional 'for loops' for IE 11
+                for (const mutation of mutationsList) {
+                    if (mutation.type === 'childList') {
+                        // The children are being changed so disconnet the observer
+                        // at first to avoid infinite loop
+                        observer.disconnect();
+                        // Render the adyen checkout components
+                        renderPaymentMethods();
+                    }
+                }
+
+                // Connect the observer again in case the checkbox is clicked
+                // multiple times
+                observer.observe(targetNode, config);
+            }
+        };
+
+        // Create an observer instance linked to the callback function
+        const observer = new MutationObserver(callback);
+
+        // Start observing the target node for configured mutations
+        try {
+            observer.observe(targetNode, config);
+        } catch (e) {
+            // observer exception
+        }
     }
 });

--- a/views/templates/front/adyencheckout.tpl
+++ b/views/templates/front/adyencheckout.tpl
@@ -70,6 +70,7 @@
         </div>
     {/if}
     <script>
+        // Use var on all variables instead of const for prestashop 1.6 one-page checkout
         var adyenCheckoutConfiguration = document.querySelector('#adyen-checkout-configuration').dataset;
 
         var IS_PRESTA_SHOP_16 = adyenCheckoutConfiguration.isPrestaShop16;
@@ -80,7 +81,7 @@
         var selectedInvoiceAddress = JSON.parse(adyenCheckoutConfiguration.selectedInvoiceAddress);
         var paymentMethodsConfigurations = JSON.parse(adyenCheckoutConfiguration.paymentMethodsConfigurations);
         var paymentMethodsWithPayButtonFromComponent = JSON.parse(adyenCheckoutConfiguration.paymentMethodsWithPayButtonFromComponent);
-        const enableStoredPaymentMethods = adyenCheckoutConfiguration.enableStoredPaymentMethods;
+        var enableStoredPaymentMethods = adyenCheckoutConfiguration.enableStoredPaymentMethods;
 
         var currencyIsoCode = adyenCheckoutConfiguration.currencyIsoCode;
         var totalAmountInMinorUnits = adyenCheckoutConfiguration.totalAmountInMinorUnits;
@@ -94,10 +95,10 @@
         };
 
         // Translated texts
-        const isNotAvailableText = "{l s=' is not available' js=1 mod='adyenofficial'}";
-        const placeOrderErrorRequiredConditionsText = "{l s='The order cannot be placed. Please make sure you accepted all the required conditions.' js=1 mod='adyenofficial'}";
-        const placeOrderInfoRequiredConditionsText = "{l s='Accept the required conditions which may be visible at the bottom of the page.' js=1 mod='adyenofficial'}";
-        const placeOrderInfoInProgressText = "{l s='Placing order is in progress' js=1 mod='adyenofficial'}";
-        const totalText = "{l s='total' js=1 mod='adyenofficial'}";
+        var isNotAvailableText = "{l s=' is not available' js=1 mod='adyenofficial'}";
+        var placeOrderErrorRequiredConditionsText = "{l s='The order cannot be placed. Please make sure you accepted all the required conditions.' js=1 mod='adyenofficial'}";
+        var placeOrderInfoRequiredConditionsText = "{l s='Accept the required conditions which may be visible at the bottom of the page.' js=1 mod='adyenofficial'}";
+        var placeOrderInfoInProgressText = "{l s='Placing order is in progress' js=1 mod='adyenofficial'}";
+        var totalText = "{l s='total' js=1 mod='adyenofficial'}";
     </script>
 {/if}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
On 1.6, if the merchant enables quick (one-page) checkout, the js in the checkout-component-renderer.js file is not executed at all.

The `ADYEN_CHECKOUT_CONFIG` is required for the **checkout-component-renderer** to function. Currently, this is set when the `hookDisplayPaymentTop` action is called.
However if one-page checkout is enabled, once the checkout page is loaded, `hookDisplayPaymentTop` is not executed, which implies that the `window.ADYEN_CHECKOUT_CONFIG` in the **checkout-component-renderer** will be set to null and so it will return without executing this js file.

Once the user fills in his guest checkout details and chooses the carrier, the payment options will be loaded, at which point the `hookDisplayPaymentTop` will be executed. However, since we do not call the **checkout-component-renderer** again (it uses `jQuery(document).ready()`), this file is not re-executed and so the functionality is unusable.

If the user refreshes, the guest user info is included in the session and the payment section of the checkout is displayed on page load. Hence, the `hookDisplayPaymentTop` will be executed and the **checkout-component-renderer** will be successfully loaded.

Hence, to sum up when the problem occurs:

* Only affects 1.6 merchants, when there is a guest customer, when one-page checkout is enabled (not by default). Also, it will work if he refreshes.

## Solution

1. Move the creation of the observer (which renders the payment methods on 1.6) above the check for the `window.ADYEN_CHECKOUT_CONFIG`
2. In this observer, set variable/s which may not have been set initially, due to the `window.ADYEN_CHECKOUT_CONFIG` being set to null
3. Add code comments to explain the changes

## Tested scenarios
* 1.6 guest test one-page checkout
* 1.6 signed-in test one-page checkout
* 1.6 guest test 5-step checkout
* 1.6 signed-in test 5-step checkout
* 1.7 guest test
* 1.7 signed-in test
