### PR TITLE
[PW-4456] - Reduce the number of requests to /paymentMethods 

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1555,7 +1555,7 @@ class AdyenOfficial extends PaymentModule
         $payment_options = array();
 
         // If we are not at the payment method step, we don't need to fetch payment methods
-        if (!$this->checkout->isPaymentMethodStepNext($this->context->cart)) {
+        if (!$this->checkout->requireFetchPaymentMethods($this->context->cart)) {
             return array();
         }
 

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -108,6 +108,11 @@ class AdyenOfficial extends PaymentModule
     private $orderStateAdapter;
 
     /**
+     * @var Adyen\PrestaShop\service\Checkout
+     */
+    private $checkout;
+
+    /**
      * Adyen constructor.
      *
      * @throws \PrestaShop\PrestaShop\Adapter\CoreException
@@ -165,6 +170,10 @@ class AdyenOfficial extends PaymentModule
 
         $this->orderStateAdapter = \Adyen\PrestaShop\service\adapter\classes\ServiceLocator::get(
             'Adyen\PrestaShop\service\adapter\classes\order\OrderStateAdapter'
+        );
+
+        $this->checkout = \Adyen\PrestaShop\service\adapter\classes\ServiceLocator::get(
+            'Adyen\PrestaShop\service\Checkout'
         );
 
         // start for 1.6
@@ -1447,6 +1456,11 @@ class AdyenOfficial extends PaymentModule
     public function hookPaymentOptions()
     {
         $payment_options = array();
+
+        // If we are not at the payment method step, we don't need to fetch payment methods
+        if (!$this->checkout->isPaymentMethodStepNext($this->context->cart)) {
+            return array();
+        }
 
         //retrieve payment methods
         $paymentMethods = $this->helper_data->fetchPaymentMethods($this->context->cart, $this->context->language);

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1668,16 +1668,23 @@ class AdyenOfficial extends PaymentModule
         $this->context->controller->addCSS('modules/' . $this->name . '/views/css/adyen.css', 'all');
 
         $payments = "";
-        $paymentMethods = $this->helper_data->fetchPaymentMethods($this->context->cart, $this->context->language);
-        if (!$this->context->customer->is_guest &&
-            !empty($paymentMethods['storedPaymentMethods']) &&
-            Configuration::get('ADYEN_ENABLE_STORED_PAYMENT_METHODS')
-        ) {
-            $payments .= $this->getOneClickPaymentMethods($paymentMethods);
+        // If the payment methods have not been fetched yet
+        if (empty($this->paymentMethods)) {
+            $this->paymentMethods = $this->helper_data->fetchPaymentMethods(
+                $this->context->cart,
+                $this->context->language
+            );
         }
 
-        if (!empty($paymentMethods['paymentMethods'])) {
-            $payments .= $this->getLocalPaymentMethods($paymentMethods);
+        if (!$this->context->customer->is_guest &&
+            !empty($this->paymentMethods['storedPaymentMethods']) &&
+            Configuration::get('ADYEN_ENABLE_STORED_PAYMENT_METHODS')
+        ) {
+            $payments .= $this->getOneClickPaymentMethods($this->paymentMethods);
+        }
+
+        if (!empty($this->paymentMethods['paymentMethods'])) {
+            $payments .= $this->getLocalPaymentMethods($this->paymentMethods);
         }
 
         return $payments;

--- a/service/Checkout.php
+++ b/service/Checkout.php
@@ -46,7 +46,8 @@ class Checkout extends \Adyen\Service\Checkout
     }
 
     /**
-     * Check if the payment method step is next in the checkout process
+     * Check if the payment method step is next in the checkout process.
+     * If an error/exception occurs return true to be safe
      *
      * @param Cart $cart
      *
@@ -59,11 +60,28 @@ class Checkout extends \Adyen\Service\Checkout
                 'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int)$cart->id
             );
 
+            if (empty($checkoutSessionData)) {
+                $this->logger->error('Session data is empty: %s', $checkoutSessionData);
+
+                return true;
+            }
+
             $jsonData = json_decode($checkoutSessionData, true);
 
-            // If delivery step is complete and payment method is reachable
-            if ($jsonData[self::DELIVERY_STEP][self::IS_COMPLETE] &&
-                $jsonData[self::PAYMENT_METHOD_STEP][self::IS_REACHABLE]) {
+            if (is_null($jsonData) && json_last_error() !== JSON_ERROR_NONE) {
+                $this->logger->error(sprintf('Invalid session JSON data: %s', $checkoutSessionData));
+
+                return true;
+            }
+
+            // Check if all keys exist, and then check if the delivery step is complete and payment method is reachable
+            if (array_key_exists(self::DELIVERY_STEP, $jsonData) &&
+                array_key_exists(self::IS_COMPLETE, $jsonData[self::DELIVERY_STEP]) &&
+                array_key_exists(self::PAYMENT_METHOD_STEP, $jsonData) &&
+                array_key_exists(self::IS_REACHABLE, $jsonData[self::PAYMENT_METHOD_STEP]) &&
+                $jsonData[self::DELIVERY_STEP][self::IS_COMPLETE] &&
+                $jsonData[self::PAYMENT_METHOD_STEP][self::IS_REACHABLE]
+            ) {
                 return true;
             }
 

--- a/service/Checkout.php
+++ b/service/Checkout.php
@@ -24,33 +24,56 @@
 
 namespace Adyen\PrestaShop\service;
 
+use Adyen\PrestaShop\service\adapter\classes\ServiceLocator;
 use Cart;
 
 class Checkout extends \Adyen\Service\Checkout
 {
     CONST PAYMENT_METHOD_STEP = 'checkout-payment-step';
+    const DELIVERY_STEP = 'checkout-delivery-step';
     const IS_REACHABLE = 'step_is_reachable';
+    const IS_COMPLETE = 'step_is_complete';
+
+    /**
+     * @var Logger
+     */
+    private $logger;
 
     public function __construct(Client $client)
     {
         parent::__construct($client);
+        $this->logger = ServiceLocator::get('Adyen\PrestaShop\service\Logger');
     }
 
     /**
+     * Check if the payment method step is next in the checkout process
+     *
      * @param Cart $cart
+     *
+     * @return bool
      */
     public function isPaymentMethodStepNext(Cart $cart)
     {
-        $checkoutSessionData = \Db::getInstance()->getValue(
-            'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int)$cart->id
-        );
+        try {
+            $checkoutSessionData = \Db::getInstance()->getValue(
+                'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int)$cart->id
+            );
 
-        $jsonData = json_decode($checkoutSessionData, true);
+            $jsonData = json_decode($checkoutSessionData, true);
 
-        if ($jsonData[self::PAYMENT_METHOD_STEP][self::IS_REACHABLE]) {
+            // If delivery step is complete and payment method is reachable
+            if ($jsonData[self::DELIVERY_STEP][self::IS_COMPLETE] &&
+                $jsonData[self::PAYMENT_METHOD_STEP][self::IS_REACHABLE]) {
+                return true;
+            }
+
+            return false;
+        } catch (\Exception $e) {
+            $this->logger->error(sprintf('An error while checking if the payment method step is next: %s',
+                $e->getMessage())
+            );
+
             return true;
         }
-
-        return false;
     }
 }

--- a/service/Checkout.php
+++ b/service/Checkout.php
@@ -46,14 +46,15 @@ class Checkout extends \Adyen\Service\Checkout
     }
 
     /**
-     * Check if the payment method step is next in the checkout process.
-     * If an error/exception occurs return true to be safe
+     * Check if the payment method step is next in the checkout process and if so,
+     * return true to require fetching payment methods. If an error/exception occurs
+     * return true to require fetching payment methods, to be on the safe side.
      *
      * @param Cart $cart
      *
      * @return bool
      */
-    public function isPaymentMethodStepNext(Cart $cart)
+    public function requireFetchPaymentMethods(Cart $cart)
     {
         try {
             $checkoutSessionData = \Db::getInstance()->getValue(

--- a/service/Checkout.php
+++ b/service/Checkout.php
@@ -24,10 +24,33 @@
 
 namespace Adyen\PrestaShop\service;
 
+use Cart;
+
 class Checkout extends \Adyen\Service\Checkout
 {
+    CONST PAYMENT_METHOD_STEP = 'checkout-payment-step';
+    const IS_REACHABLE = 'step_is_reachable';
+
     public function __construct(Client $client)
     {
         parent::__construct($client);
+    }
+
+    /**
+     * @param Cart $cart
+     */
+    public function isPaymentMethodStepNext(Cart $cart)
+    {
+        $checkoutSessionData = \Db::getInstance()->getValue(
+            'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int)$cart->id
+        );
+
+        $jsonData = json_decode($checkoutSessionData, true);
+
+        if ($jsonData[self::PAYMENT_METHOD_STEP][self::IS_REACHABLE]) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/service/Checkout.php
+++ b/service/Checkout.php
@@ -29,7 +29,7 @@ use Cart;
 
 class Checkout extends \Adyen\Service\Checkout
 {
-    CONST PAYMENT_METHOD_STEP = 'checkout-payment-step';
+    const PAYMENT_METHOD_STEP = 'checkout-payment-step';
     const DELIVERY_STEP = 'checkout-delivery-step';
     const IS_REACHABLE = 'step_is_reachable';
     const IS_COMPLETE = 'step_is_complete';
@@ -69,8 +69,8 @@ class Checkout extends \Adyen\Service\Checkout
 
             return false;
         } catch (\Exception $e) {
-            $this->logger->error(sprintf('An error while checking if the payment method step is next: %s',
-                $e->getMessage())
+            $this->logger->error(
+                sprintf('An error while checking if the payment method step is next: %s', $e->getMessage())
             );
 
             return true;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The PrestaShop plugin makes unnecessary requests to the `/paymentMethods` Adyen endpoint. The requests are all done by the `fetchPaymentMethods` function in the adyenofficial file. This function is called by the following hooks:

* hookDisplayPaymentTop
* hookPaymentOptions (1.7)
* hookPayment (1.6)

Currently, for a single transaction the following api calls are done:

* 1.7 - **4 calls** to /paymentMethods
    * 1 in `hookDisplayPaymentTop`
    * 3 (1 for each of the 3 steps when already signed in) in `hookPaymentOptions`
* 1.6 (5-page checkout) - **2 calls** to /paymentMethods
    * 1 in `hookDisplayPaymentTop`
    * 1 in `hookPayment`
* 1.6 (1-page checkout) - **3 calls** to /paymentMethods
    * 2 in `hookDisplayPaymentTop`
    * 1 in `hookPayment`

After this PR is merged:

* 1.7 - **1 call** to /paymentMethods. 
    * 1 in `hookPaymentOptions`
* 1.6 (5-page checkout) - **1 call** to /paymentMethods.
    * 1 in `hookDisplayPaymentTop`
* 1.6 (1-page checkout) - **2 calls** to /paymentMethods
    * 2 in `hookDisplayPaymentTop` (since AdyenOfficial is instantiated on page load and on agreement to T&C).

## Tested scenarios
* All scenarios mentioned above
* E2E tests
