### PR TITLE
[PW-4877] - Create configuration for adyen styling

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -871,6 +871,7 @@ class AdyenOfficial extends PaymentModule
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
             $payment_display_collapse = Tools::getValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
             $enable_stored_payment_methods = Tools::getValue('ADYEN_ENABLE_STORED_PAYMENT_METHODS');
+            $enable_checkout_styling = Tools::getValue('ADYEN_ENABLE_CHECKOUT_STYLING');
 
             // validating the input
             if (empty($merchant_account) || !Validate::isGenericName($merchant_account)) {
@@ -933,6 +934,7 @@ class AdyenOfficial extends PaymentModule
                 Configuration::updateValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER', $google_pay_merchant_identifier);
                 Configuration::updateValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE', $payment_display_collapse);
                 Configuration::updateValue('ADYEN_ENABLE_STORED_PAYMENT_METHODS', $enable_stored_payment_methods);
+                Configuration::updateValue('ADYEN_ENABLE_CHECKOUT_STYLING', $enable_checkout_styling);
                 Configuration::updateValue(
                     'ADYEN_ADMIN_PATH',
                     $this->crypto->encrypt(basename(_PS_ADMIN_DIR_))
@@ -1444,6 +1446,28 @@ class AdyenOfficial extends PaymentModule
 
         // Developer settings
         $fields_form[5]['form']['input'][] = array(
+            'type' => 'radio',
+            'label' => $this->l('Adyen checkout styling'),
+            'name' => 'ADYEN_ENABLE_CHECKOUT_STYLING',
+            'values' => array(
+                array(
+                    'id' => 'enable',
+                    'value' => 1,
+                    'label' => $this->l('Enable')
+                ),
+                array(
+                    'id' => 'disable',
+                    'value' => 0,
+                    'label' => $this->l('Disable')
+                )
+            ),
+            'is_bool' => true,
+            // phpcs:ignore Generic.Files.LineLength.TooLong
+            'hint' => 'Indicates whether the CSS styling provided by Adyen should be loaded or not, in the checkout page',
+            'required' => false
+        );
+
+        $fields_form[5]['form']['input'][] = array(
             'type' => 'text',
             'label' => $this->l('Integrator Name'),
             'name' => 'ADYEN_INTEGRATOR_NAME',
@@ -1503,6 +1527,7 @@ class AdyenOfficial extends PaymentModule
             $google_pay_merchant_identifier = Tools::getValue('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
             $payment_display_collapse = Tools::getValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
             $enable_stored_payment_methods = Tools::getValue('ADYEN_ENABLE_STORED_PAYMENT_METHODS');
+            $enable_adyen_checkout_styling = Tools::getValue('ADYEN_ENABLE_CHECKOUT_STYLING');
         } else {
             $merchant_account = Configuration::get('ADYEN_MERCHANT_ACCOUNT');
             $integrator_name = Configuration::get('ADYEN_INTEGRATOR_NAME');
@@ -1518,6 +1543,7 @@ class AdyenOfficial extends PaymentModule
             $google_pay_merchant_identifier = Configuration::get('ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER');
             $payment_display_collapse = Configuration::get('ADYEN_PAYMENT_DISPLAY_COLLAPSE');
             $enable_stored_payment_methods = Configuration::get('ADYEN_ENABLE_STORED_PAYMENT_METHODS');
+            $enable_adyen_checkout_styling = Configuration::get('ADYEN_ENABLE_CHECKOUT_STYLING');
         }
 
         // Load current value
@@ -1536,6 +1562,7 @@ class AdyenOfficial extends PaymentModule
         $helper->fields_value['ADYEN_GOOGLE_PAY_MERCHANT_IDENTIFIER'] = $google_pay_merchant_identifier;
         $helper->fields_value['ADYEN_PAYMENT_DISPLAY_COLLAPSE'] = $payment_display_collapse;
         $helper->fields_value['ADYEN_ENABLE_STORED_PAYMENT_METHODS'] = $enable_stored_payment_methods;
+        $helper->fields_value['ADYEN_ENABLE_CHECKOUT_STYLING'] = $enable_adyen_checkout_styling;
 
         return $helper->generateForm($fields_form);
     }

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -882,7 +882,8 @@ class AdyenOfficial extends PaymentModule
                 $output .= $this->displayError($this->l('Invalid configuration value for Integrator Name'));
             }
 
-            if (empty($notification_username) || !Validate::isGenericName($notification_username)) {
+            if ((empty($notification_username) || !Validate::isGenericName($notification_username)) &&
+                $mode === 'live') {
                 $output .= $this->displayError($this->l('Invalid configuration value for Webhook Username'));
             }
 
@@ -912,12 +913,12 @@ class AdyenOfficial extends PaymentModule
 
             $storedNotiPass = Configuration::get('ADYEN_NOTI_PASSWORD');
             if (empty($notification_password) && empty($storedNotiPass) && $mode === 'live') {
-                $output .= $this->displayError($this->l('Invalid configuration value for the webhook password'));
+                $output .= $this->displayError($this->l('Invalid configuration value for the Webhook password'));
             }
 
             $storedNotiHmac = Configuration::get('ADYEN_NOTI_HMAC');
             if (empty($notification_hmac) && empty($storedNotiHmac) && $mode === 'live') {
-                $output .= $this->displayError($this->l('Invalid configuration value for the webhook HMAC'));
+                $output .= $this->displayError($this->l('Invalid configuration value for the Webhook HMAC'));
             }
 
             if ($output == null) {

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1684,7 +1684,11 @@ class AdyenOfficial extends PaymentModule
             return null;
         }
 
-        $this->context->controller->addCSS('modules/' . $this->name . '/views/css/adyen.css', 'all');
+        $loadAdyenCss = Configuration::get('ADYEN_ENABLE_CHECKOUT_STYLING');
+
+        if ($loadAdyenCss) {
+            $this->context->controller->addCSS('modules/' . $this->name . '/views/css/adyen.css', 'all');
+        }
 
         $payments = "";
         $paymentMethods = $this->helper_data->fetchPaymentMethods($this->context->cart, $this->context->language);
@@ -2201,10 +2205,14 @@ class AdyenOfficial extends PaymentModule
             array('position' => 'bottom', 'priority' => 170)
         );
 
-        $controllerAdapter->registerStylesheet(
-            'adyen-adyencss',
-            'modules/' . $this->name . '/views/css/adyen.css'
-        );
+        $enableAdyenCss = Configuration::get('ADYEN_ENABLE_CHECKOUT_STYLING');
+
+        if ($enableAdyenCss) {
+            $controllerAdapter->registerStylesheet(
+                'adyen-adyencss',
+                'modules/' . $this->name . '/views/css/adyen.css'
+            );
+        }
 
         // Only for Order and Order one page checkout controller
         if ($controller->php_self == 'order' || $controller->php_self == 'order-opc') {

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -214,7 +214,8 @@ class AdyenOfficial extends PaymentModule
             'ADYEN_AUTO_CRON_JOB_RUNNER',
             'ADYEN_ADMIN_PATH',
             'ADYEN_ENABLE_STORED_PAYMENT_METHODS',
-            'ADYEN_PAYMENT_DISPLAY_COLLAPSE'
+            'ADYEN_PAYMENT_DISPLAY_COLLAPSE',
+            'ADYEN_ENABLE_CHECKOUT_STYLING'
         );
 
         $testConfigs = array(
@@ -339,7 +340,8 @@ class AdyenOfficial extends PaymentModule
         return $this->updateCronJobToken() &&
             $this->setDefaultConfigurationForAutoCronjobRunner() &&
             $this->setDefaultConfigurationForEnableStoredPaymentMethods() &&
-            $this->setDefaultConfigurationForPaymentDisplayCollapse();
+            $this->setDefaultConfigurationForPaymentDisplayCollapse() &&
+            $this->setDefaultConfigurationForEnableAdyenCheckoutStyling();
     }
 
     /**
@@ -666,6 +668,14 @@ class AdyenOfficial extends PaymentModule
     public function setDefaultConfigurationForPaymentDisplayCollapse()
     {
         return Configuration::updateValue('ADYEN_PAYMENT_DISPLAY_COLLAPSE', 0);
+    }
+
+    /**
+     * @return bool
+     */
+    public function setDefaultConfigurationForEnableAdyenCheckoutStyling()
+    {
+        return Configuration::updateValue('ADYEN_ENABLE_CHECKOUT_STYLING', 1);
     }
 
     /**

--- a/upgrade/upgrade-3.7.0.php
+++ b/upgrade/upgrade-3.7.0.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop plugin
+ *
+ * @author Adyen BV <support@adyen.com>
+ * @copyright (c) 2021 Adyen B.V.
+ * @license https://opensource.org/licenses/MIT MIT license
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+// This file declares a function and checks if PrestaShop is loaded to follow
+// PrestaShop's good practices, which breaks a PSR1 element.
+//phpcs:disable PSR1.Files.SideEffects
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * This function is automatically called on version upgrade
+ *
+ * @param AdyenOfficial $module
+ *
+ * @return bool
+ */
+function upgrade_module_3_7_0(AdyenOfficial $module)
+{
+    return $module->setDefaultConfigurationForEnableAdyenCheckoutStyling() &&
+        add_payment_display_collapse($module);
+}
+
+/**
+ * On 1.6, check if payment display collapse has been added trough a previous installation,
+ * if not add it
+ *
+ * @param AdyenOfficial $module
+ * @return bool
+ */
+function add_payment_display_collapse(AdyenOfficial $module)
+{
+    if (version_compare(_PS_VERSION_, '1.7', '>=')) {
+        return true;
+    }
+
+    $payment_display_collapse = Configuration::get(
+        'ADYEN_PAYMENT_DISPLAY_COLLAPSE',
+        null,
+        null,
+        null,
+        null
+    );
+
+    if (is_null($payment_display_collapse)) {
+        return $module->setDefaultConfigurationForPaymentDisplayCollapse();
+    }
+
+    return true;
+}

--- a/views/css/adyen.css
+++ b/views/css/adyen.css
@@ -143,3 +143,13 @@ body#checkout section.checkout-step .payment-options label {
 .adyen-payment .adyen-collapser.adyen-payment-method-label {
     cursor: pointer;
 }
+
+@media only screen and (max-width: 480px) {
+    body#checkout section.checkout-step .payment-options .custom-radio {
+        margin-right: 0;
+    }
+
+    .payment-option label {
+        text-align: left;
+    }
+}

--- a/views/js/adyen-admin.js
+++ b/views/js/adyen-admin.js
@@ -24,7 +24,7 @@
 jQuery(document).ready(function() {
     const prodSection = $("div:contains('Production Settings'):last").parent();
     const testSection = $("div:contains('Test Settings'):last").parent();
-    const notificationSection = $("div:contains('Notification Settings'):last").parent();
+    const notificationSection = $("div:contains('Webhook Settings'):last").parent();
     const radioInput = $("#configuration_form input[name='ADYEN_MODE']");
     populateApiKeys();
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
A new configuration value to enable/disable the adyen styling should be created. When enabled, the adyen css file will be loaded whereas it won't be loaded if the config is disabled. This will help merchants that want to style the checkout page themselves, by not applying the styling of our files.

## Tested scenarios
* Config enabled
* Config disabled
