### PR TITLE
[PW-4943] - Update logable value of our WAITING_FOR_PAYMENT state

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -586,7 +586,7 @@ class AdyenOfficial extends PaymentModule
             $newOrderState->module_name = $this->name;
             $newOrderState->invoice = false;
             $newOrderState->color = '#4169E1';
-            $newOrderState->logable = true;
+            $newOrderState->logable = false;
             $newOrderState->delivery = false;
             $newOrderState->hidden = false;
             $newOrderState->shipped = false;

--- a/upgrade/upgrade-3.7.1.php
+++ b/upgrade/upgrade-3.7.1.php
@@ -68,7 +68,7 @@ function set_waiting_for_payment_status_logable_to_false()
 
     return Db::getInstance(_PS_USE_SQL_SLAVE_)->update(
         'order_state',
-        ['logable' => false],
+        array('logable' => false),
         'id_order_state = ' . $orderStateConfigurationId,
         1
     );

--- a/upgrade/upgrade-3.7.1.php
+++ b/upgrade/upgrade-3.7.1.php
@@ -66,8 +66,10 @@ function set_waiting_for_payment_status_logable_to_false()
         return false;
     }
 
-    $orderState->logable = false;
-    $orderState->save();
-
-    return true;
+    return Db::getInstance(_PS_USE_SQL_SLAVE_)->update(
+        'order_state',
+        ['logable' => false],
+        'id_order_state = ' . $orderStateConfigurationId,
+        1
+    );
 }

--- a/upgrade/upgrade-3.7.1.php
+++ b/upgrade/upgrade-3.7.1.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen PrestaShop plugin
+ *
+ * @author Adyen BV <support@adyen.com>
+ * @copyright (c) 2021 Adyen B.V.
+ * @license https://opensource.org/licenses/MIT MIT license
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+// This file declares a function and checks if PrestaShop is loaded to follow
+// PrestaShop's good practices, which breaks a PSR1 element.
+//phpcs:disable PSR1.Files.SideEffects
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * This function is automatically called on version upgrade
+ *
+ * @param AdyenOfficial $module
+ *
+ * @return bool
+ */
+function upgrade_module_3_7_1(AdyenOfficial $module)
+{
+    return set_waiting_for_payment_status_logable_to_false();
+}
+
+/**
+ * Set the logable field of the WAITING_FOR_PAYMENT status to false
+ *
+ * @return bool
+ */
+function set_waiting_for_payment_status_logable_to_false()
+{
+    $orderStateConfigurationId = Configuration::get('ADYEN_OS_WAITING_FOR_PAYMENT');
+
+    $orderState = false;
+    if ($orderStateConfigurationId) {
+        /** @var $orderState OrderState */
+        $orderState = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            '
+                SELECT *
+                FROM `' . _DB_PREFIX_ . 'order_state`
+                WHERE deleted = 0 AND `id_order_state` = ' . (int)$orderStateConfigurationId
+        );
+    }
+
+    if (empty($orderState)) {
+        return false;
+    }
+
+    $orderState->logable = false;
+    $orderState->save();
+
+    return true;
+}

--- a/upgrade/upgrade-3.7.1.php
+++ b/upgrade/upgrade-3.7.1.php
@@ -69,7 +69,7 @@ function set_waiting_for_payment_status_logable_to_false()
     return Db::getInstance(_PS_USE_SQL_SLAVE_)->update(
         'order_state',
         array('logable' => false),
-        'id_order_state = ' . $orderStateConfigurationId,
+        'id_order_state = ' . (int)$orderStateConfigurationId,
         1
     );
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The **WAITING_FOR_PAYMENT** order state should have a logable value of 0. This should be done since when the order is in this status, no payment has been processed yet and hence, no OrderPayment linked to this order should be created. This will also ensure that the `total_paid_real` db value, will only be updated once the payment actually goes trough, and not during the redirection.

**Steps:**
1. When creating the WAITING_FOR_PAYMENT state, set the `logable` value to 0.
3. Create upgrade script

## Tested scenarios
* `total_paid_real = 0` during redirection on 1.6
* `total_paid_real = 0` during redirection on 1.7

## Fixed issues

#192 