### PR TITLE
[PW-5091] Do not set payment source application information

### DIFF
--- a/service/Client.php
+++ b/service/Client.php
@@ -73,7 +73,6 @@ class Client extends \Adyen\Client
         }
 
         $this->setXApiKey($apiKey);
-        $this->setAdyenPaymentSource($configuration->moduleName, $configuration->moduleVersion);
         $this->setMerchantApplication($configuration->moduleName, $configuration->moduleVersion);
         $this->setExternalPlatform("PrestaShop", _PS_VERSION_, $configuration->integratorName);
         $this->setEnvironment($configuration->adyenMode, $configuration->liveEndpointPrefix);


### PR DESCRIPTION
## Summary
The payment source application information field duplicates the merchant application and not necessary
anymore. See [docs page](https://docs.adyen.com/development-resources/building-adyen-solutions#building-a-plugin)
