### PR TITLE
Bump ubuntu version to 18.04

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-16.04, ubuntu-latest]
+        operating-system: [ubuntu-18.04, ubuntu-latest]
         php-version: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
 
     steps:


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Ubuntu 16.04 is deprecated so it needs to be moved to 18.04 in order to be able to run the test correctly
