### PR TITLE
Add hook to NotificationProcessor::processNotification

### DIFF
--- a/service/notification/NotificationProcessor.php
+++ b/service/notification/NotificationProcessor.php
@@ -150,6 +150,18 @@ class NotificationProcessor
      */
     public function processNotification($unprocessedNotification)
     {
+        // try to process the notification in other modules
+        /* @var null|boolean $hookResult */
+        $hookResult = null;
+        Hook::exec(
+            'actionAdyenProcessNotificationBefore',
+            ['unprocessedNotification' => $unprocessedNotification, 'hookResult' => &$hookResult]
+        );
+        // if $hookResult is not null, the notification have been processed by an other module
+        if ($hookResult !== null) {
+            return $hookResult;
+        }
+        
         // Validate if order is available by merchant reference
         /* @var OrderCore $order */
         $order = $this->orderAdapter->getOrderByCartId($unprocessedNotification['merchant_reference']);


### PR DESCRIPTION
## Summary
Try to process the notification in other modules before doing the default process. Usefull for partial refunds or additional payments that the module does not manage
