### PR TITLE
[PW-6058] - Fetch payment methods on virtual cart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @acampos1916 @rikterbeek @Morerice
+* @acampos1916 @rikterbeek @Morerice @tnaber @michaelpaul @peterojo @AlexandrosMor

--- a/service/Checkout.php
+++ b/service/Checkout.php
@@ -56,6 +56,7 @@ class Checkout extends \Adyen\Service\Checkout
      */
     public function requireFetchPaymentMethods(Cart $cart)
     {
+        $isVirtualCart = $cart->isVirtualCart();
         try {
             $checkoutSessionData = \Db::getInstance()->getValue(
                 'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int)$cart->id
@@ -76,11 +77,11 @@ class Checkout extends \Adyen\Service\Checkout
             }
 
             // Check if all keys exist, and then check if the delivery step is complete and payment method is reachable
-            if (array_key_exists(self::DELIVERY_STEP, $jsonData) &&
+            if (($isVirtualCart || array_key_exists(self::DELIVERY_STEP, $jsonData)) &&
                 array_key_exists(self::IS_COMPLETE, $jsonData[self::DELIVERY_STEP]) &&
                 array_key_exists(self::PAYMENT_METHOD_STEP, $jsonData) &&
                 array_key_exists(self::IS_REACHABLE, $jsonData[self::PAYMENT_METHOD_STEP]) &&
-                $jsonData[self::DELIVERY_STEP][self::IS_COMPLETE] &&
+                ($isVirtualCart || $jsonData[self::DELIVERY_STEP][self::IS_COMPLETE]) &&
                 $jsonData[self::PAYMENT_METHOD_STEP][self::IS_REACHABLE]
             ) {
                 return true;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently when a shopper is checking out with a virtual cart (all products to be bought are virtual) the adyen payment methods are not being fetched and displayed. This is due to a check on the delivery step of the checkout process, which on a virtual cart will not exist.

This PR will solve this issue by checking if the cart is virtual and if so, omitting the check on the delivery step.

## Tested scenarios
* Checkout with a virtual cart
* Checkout with a normal cart
* Checkout with a mixed cart (1 virtual, 1 normal)

