### PR TITLE
fix: Cart cloned without product customization after a canceled/refused payment

### DIFF
--- a/service/Cart.php
+++ b/service/Cart.php
@@ -24,8 +24,21 @@
 
 namespace Adyen\PrestaShop\service;
 
+use Adyen\PrestaShop\service\adapter\classes\ServiceLocator;
+use CartRuleCore as CartRule;
+
 class Cart
 {
+    /**
+     * @var Adyen\PrestaShop\service\Logger
+     */
+    private $logger;
+ 
+    public function __construct()
+    {
+        $this->logger = ServiceLocator::get('Adyen\PrestaShop\service\Logger');
+    }
+
     /**
      * Clones cart and updates the context
      *
@@ -33,66 +46,37 @@ class Cart
      * @param \Cart $cart
      * @param bool $isPrestashop16
      */
-    public function cloneCurrentCart(\Context $context, \Cart $cart, $isPrestashop16)
+    public function cloneCurrentCart(\Context $context, \Cart $cart, bool $isPrestashop16)
     {
-        // To save the secure key of current cart id and reassign the same to new cart
-        $old_cart_secure_key = $cart->secure_key;
-        // To save the customer id of current cart id and reassign the same to new cart
-        $old_cart_customer_id = (int)$cart->id_customer;
-        $old_delivery_address_id = $cart->id_address_delivery;
-        $old_invoice_address_id = $cart->id_address_invoice;
+        $duplication = $cart->duplicate();
 
-        // To fetch the current cart products
-        $cart_products = $cart->getProducts();
-        // Creating new cart object
-        $context->cart = new \Cart();
-        $context->cart->id_lang = $context->language->id;
-        $context->cart->id_address_delivery = $old_delivery_address_id;
-        $context->cart->id_address_invoice = $old_invoice_address_id;
-
-        $context->cart->id_currency = $context->currency->id;
-        $context->cart->secure_key = $old_cart_secure_key;
-        // to add new cart
-        $context->cart->add();
-        $newCartId  = $context->cart->id;
-        // to update the new cart
-        foreach ($cart_products as $product) {
-            $context->cart->updateQty(
-                (int)$product['quantity'],
-                (int)$product['id_product'],
-                (int)$product['id_product_attribute']
-            );
-        }
-        if ($context->cookie->id_guest) {
-            $guest = new \Guest($context->cookie->id_guest);
-            $context->cart->mobile_theme = $guest->mobile_theme;
-        }
-
-        // Field does not exist in prestashop 16
-        // Else set the cart qties manually to ensure consistency with layout header
-        if (!$isPrestashop16) {
-            // Get the checkout_session_data field of the previous cart
-            $checkoutSessionData = \Db::getInstance()->getValue(
-                'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int)$cart->id
-            );
-
-            // Update the checkout_session_data field of the new cart
-            \Db::getInstance()->execute(
-                'UPDATE ' . _DB_PREFIX_ . 'cart SET checkout_session_data = "' . pSQL($checkoutSessionData) . '"
-        WHERE id_cart = ' . (int)$newCartId
-            );
+        if (!$duplication
+            || !is_object($duplication['cart'])
+            || !$duplication['cart']->id
+            || !$duplication['success']) {
+            $this->logger->error('Adyen module was unable to duplicate cart with id: ' . $cart->id);
         } else {
-            $context->smarty->assign('cart_qties', $context->cart->nbProducts());
-        }
+            $context->cookie->id_cart = $duplication['cart']->id;
+            $context->cart = $duplication['cart'];
+            CartRule::autoAddToCart($context);
 
-        // to map the new cart with the customer
-        $context->cart->id_customer = $old_cart_customer_id;
-        $context->cart->id_guest = $cart->id_guest;
+            // Field does not exist in prestashop 16
+            // Else set the cart qties manually to ensure consistency with layout header
+            if (!$isPrestashop16) {
+                // Get the checkout_session_data field of the previous cart
+                $checkoutSessionData = \Db::getInstance()->getValue(
+                    'SELECT checkout_session_data FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart = ' . (int)$cart->id
+                );
 
-        // to save the new cart
-        $context->cart->save();
-        if ($context->cart->id) {
-            $context->cookie->id_cart = (int)$context->cart->id;
+                // Update the checkout_session_data field of the new cart
+                \Db::getInstance()->execute(
+                    'UPDATE ' . _DB_PREFIX_ . 'cart SET checkout_session_data = "' . pSQL($checkoutSessionData) . '"
+                    WHERE id_cart = ' . (int)$context->cart->id
+                );
+            } else {
+                $context->smarty->assign('cart_qties', $context->cart->nbProducts());
+            }
+
             $context->cookie->write();
         }
     }


### PR DESCRIPTION
This PR is intended to fix the issue of a duplicated cart containing products with lost customizations after a payment is canceled/refused.

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Rather than creating your own cart duplication function, you may use the existing one in Prestashop `Cart.php` class in the same way this is done in the Prestashop `controllers/front/OrderController.php`, in the `postPorcess` function:
https://github.com/PrestaShop/PrestaShop/blob/14cb6a4c6e72c55c16a95cfbe4aeb8e44fe73ab5/controllers/front/OrderController.php#L57
The `postProcess` function also takes care of updating the cookie.

The `Cart->duplicate()` function also exists in Prestashop 1.6 (still I didn't have any PS 1.6 to test it on).

I reproduced the existing `checkout_session_data` update in my modified `cloneCurrentCart` function even though I'm not sure the checksum of the duplicated cart is the same as the one of the original cart, but this doesn't seem to cause any issue regarding what's I am fixing (it works with ou or without this updated `checkout_session_data` in database).

## Tested scenarios
<!-- Description of tested scenarios -->
The following tests have been made with a Prestashop 1.7.7.8:
- [x]  Buy one customized product with successful payment
- [x]  Buy multiple customized product with successful payment
- [x]  Try to buy one customized products with 3D secure authentication failed. The duplicated cart is the same as the original one, and product customizations is well duplicated. 
- [x]  Re-executing the payment on this duplicated cart, with a valid 3D secure Authentication, runs fine and the order is completed with the customized product
- [x]  Try to buy multiple customized products with 3D secure authentication failed. The duplicated cart is the same as the original one, and products customizations are well duplicated
- [x]  Re-executing the payment on this duplicated cart, with a valid 3D secure Authentication, runs fine and the order is completed with the customized products


**Fixed issue**:  #253 
