### PR TITLE
Release version 4.0.5

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -128,7 +128,7 @@ class AdyenOfficial extends PaymentModule
     {
         $this->module_key = '0d28de799435cd859f10e31f2edafc39';
         $this->name = 'adyenofficial';
-        $this->version = '4.0.3';
+        $this->version = '4.0.5';
         $this->tab = 'payments_gateways';
         $this->author = 'Adyen';
         $this->bootstrap = true;

--- a/controllers/admin/AdminAdyenOfficialPrestashopValidatorController.php
+++ b/controllers/admin/AdminAdyenOfficialPrestashopValidatorController.php
@@ -252,10 +252,8 @@ class AdminAdyenOfficialPrestashopValidatorController extends ModuleAdminControl
         $registeredHookList = Hook::getHookModuleList();
         foreach ($hooks_list as &$current_hook) {
             $hook_name = $current_hook['name'];
-            $retro_hook_name = Hook::getRetroHookName($hook_name);
 
-            if (is_callable([$this->module, 'hook' . Tools::ucfirst($hook_name)]) ||
-                is_callable([$this->module, 'hook' . Tools::ucfirst($retro_hook_name)])) {
+            if (is_callable([$this->module, 'hook' . Tools::ucfirst($hook_name)])) {
                 $possible_hooks_list[] = [
                     'id_hook' => $current_hook['id_hook'],
                     'name' => $hook_name,

--- a/service/adapter/classes/Configuration.php
+++ b/service/adapter/classes/Configuration.php
@@ -72,7 +72,7 @@ class Configuration
         $this->encryptedApiKey = $this->getEncryptedAPIKey();
         $this->clientKey = $this->getClientKey();
         $this->liveEndpointPrefix = \Configuration::get('ADYEN_LIVE_ENDPOINT_URL_PREFIX');
-        $this->moduleVersion = '4.0.3';
+        $this->moduleVersion = '4.0.5';
         $this->moduleName = 'adyen-prestashop';
         $this->integratorName = \Configuration::get('ADYEN_INTEGRATOR_NAME', null, null, null, '');
     }


### PR DESCRIPTION
## Summary
Remove call of now removed Hook::getRetroHookName PS method from AdminAdyenOfficialPrestashopValidatorController

## Tested scenarios
Fixes are tested on PrestaShop 8.0.1 and 1.7.8.8

**Fixed issue**:  [MAIN-1677](https://logeecom.atlassian.net/browse/MAIN-1677)
