### PR TITLE
prestashop 9 logger addRecord bug fix for Monolog compatibility

### DIFF
--- a/service/Logger.php
+++ b/service/Logger.php
@@ -197,10 +197,10 @@ class Logger extends \Monolog\Logger
      *
      * @return bool Whether the record has been processed
      */
-    public function addRecord($level, $message, array $context = [], $callPrestaShopLogger = true)
+    public function addRecord(int $level, string $message, array $context = [], ?\Monolog\DateTimeImmutable $datetime = null): bool
     {
         $context['is_exception'] = $message instanceof \Exception;
-        if (array_key_exists($level, self::$prestashopLoggable) && $callPrestaShopLogger) {
+        if (array_key_exists($level, self::$prestashopLoggable)) {
             \PrestaShopLogger::addLog(
                 $message,
                 self::$prestashopLoggable[$level],
@@ -211,7 +211,7 @@ class Logger extends \Monolog\Logger
             );
         }
 
-        return parent::addRecord($level, $message, $context);
+        return parent::addRecord($level, $message, $context, $datetime);
     }
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
Prestashop 9 throws an error from Logger->addRecord
```php
Compile Error: Declaration of Adyen\PrestaShop\service\Logger::addRecord($level, $message, array $context = [], $callPrestaShopLogger = true) 
must be compatible with Monolog\Logger::addRecord(int $level, string $message, array $context = [], ?Monolog\DateTimeImmutable $datetime = null): bool
```
- What existing problem does this pull request solve?
Prestashop 9 compatibility

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
Fix:
```php
public function addRecord(int $level, string $message, array $context = [], ?\Monolog\DateTimeImmutable $datetime = null): bool
    {
        $context['is_exception'] = $message instanceof \Exception;
        if (array_key_exists($level, self::$prestashopLoggable)) {
            \PrestaShopLogger::addLog(
                $message,
                self::$prestashopLoggable[$level],
                null,
                null,
                null,
                true
            );
        }

        return parent::addRecord($level, $message, $context, $datetime);
    }
```