### PR TITLE
Fix issues with GooglePay and PayPal

### DIFF
--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -128,7 +128,7 @@ class AdyenOfficial extends PaymentModule
     {
         $this->module_key = '0d28de799435cd859f10e31f2edafc39';
         $this->name = 'adyenofficial';
-        $this->version = '4.0.6';
+        $this->version = '4.0.7';
         $this->tab = 'payments_gateways';
         $this->author = 'Adyen';
         $this->bootstrap = true;

--- a/adyenofficial.php
+++ b/adyenofficial.php
@@ -1773,7 +1773,7 @@ class AdyenOfficial extends PaymentModule
         );
 
         // List of payment methods that needs to show the pay button from the component
-        $paymentMethodsWithPayButtonFromComponent = json_encode(['paywithgoogle', 'applepay', 'paypal']);
+        $paymentMethodsWithPayButtonFromComponent = json_encode(['googlepay', 'paywithgoogle', 'applepay', 'paypal']);
 
         // All payment method specific configuration
         $paymentMethodsConfigurations = json_encode(

--- a/service/adapter/classes/Configuration.php
+++ b/service/adapter/classes/Configuration.php
@@ -72,7 +72,7 @@ class Configuration
         $this->encryptedApiKey = $this->getEncryptedAPIKey();
         $this->clientKey = $this->getClientKey();
         $this->liveEndpointPrefix = \Configuration::get('ADYEN_LIVE_ENDPOINT_URL_PREFIX');
-        $this->moduleVersion = '4.0.6';
+        $this->moduleVersion = '4.0.7';
         $this->moduleName = 'adyen-prestashop';
         $this->integratorName = \Configuration::get('ADYEN_INTEGRATOR_NAME', null, null, null, '');
     }

--- a/service/builder/Payment.php
+++ b/service/builder/Payment.php
@@ -38,6 +38,7 @@ class Payment
         $request['channel'] = 'web';
         $request['origin'] = $origin;
         $request['shopperInteraction'] = 'Ecommerce';
+        $request['storePaymentMethod'] = $request['storePaymentMethod'] === 'true';
 
         return $request;
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Google Pay button not showing on checkout.
Issue with missing request data for PayPal.

## Tested scenarios
Fix is tested on PrestaShop 8.0.2.


**Fixed issue**:  <!-- #-prefixed issue number -->(https://logeecom.atlassian.net/browse/CS-4395)
