### PR TITLE
Fix - Cannot declare class Autoloader, because the name is already in use

### DIFF
--- a/src/upgrade/Autoloader.php
+++ b/src/upgrade/Autoloader.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace AdyenPayment;
+
 class Autoloader
 {
     /**

--- a/src/upgrade/upgrade-5.0.0.php
+++ b/src/upgrade/upgrade-5.0.0.php
@@ -46,8 +46,8 @@ require_once 'Autoloader.php';
  */
 function upgrade_module_5_0_0(AdyenOfficial $module): bool
 {
-    Autoloader::setFileExt('.php');
-    spl_autoload_register('Autoloader::loader');
+    \AdyenPayment\Autoloader::setFileExt('.php');
+    spl_autoload_register('\AdyenPayment\Autoloader::loader');
 
     $previousShopContext = Shop::getContext();
     Shop::setContext(ShopCore::CONTEXT_ALL);
@@ -81,7 +81,7 @@ function upgrade_module_5_0_0(AdyenOfficial $module): bool
     getQueueService()->enqueue('general-migration', new MigrateTransactionHistoryTask());
     removeObsoleteData();
 
-    spl_autoload_unregister('Autoloader::loader');
+    spl_autoload_unregister('\AdyenPayment\Autoloader::loader');
 
     $module->enable();
     Shop::setContext(ShopCore::CONTEXT_SHOP, $previousShopContext);

--- a/src/upgrade/upgrade-5.1.12.php
+++ b/src/upgrade/upgrade-5.1.12.php
@@ -22,8 +22,8 @@ require_once 'Autoloader.php';
  */
 function upgrade_module_5_1_12(AdyenOfficial $module): bool
 {
-    Autoloader::setFileExt('.php');
-    spl_autoload_register('Autoloader::loader');
+    \AdyenPayment\Autoloader::setFileExt('.php');
+    spl_autoload_register('\AdyenPayment\Autoloader::loader');
     Shop::setContext(ShopCore::CONTEXT_ALL);
     $installer = new \AdyenPayment\Classes\Utility\Installer($module);
     $pendingState = 'Pending';

--- a/src/upgrade/upgrade-5.1.9.php
+++ b/src/upgrade/upgrade-5.1.9.php
@@ -22,8 +22,8 @@ require_once 'Autoloader.php';
  */
 function upgrade_module_5_1_9(AdyenOfficial $module): bool
 {
-    Autoloader::setFileExt('.php');
-    spl_autoload_register('Autoloader::loader');
+    \AdyenPayment\Autoloader::setFileExt('.php');
+    spl_autoload_register('\AdyenPayment\Autoloader::loader');
     Shop::setContext(ShopCore::CONTEXT_ALL);
     $installer = new \AdyenPayment\Classes\Utility\Installer($module);
 

--- a/src/upgrade/upgrade-5.2.0.php
+++ b/src/upgrade/upgrade-5.2.0.php
@@ -22,8 +22,9 @@ require_once 'Autoloader.php';
  */
 function upgrade_module_5_2_0(AdyenOfficial $module): bool
 {
-    Autoloader::setFileExt('.php');
-    spl_autoload_register('Autoloader::loader');
+
+    \AdyenPayment\Autoloader::setFileExt('.php');
+    spl_autoload_register('\AdyenPayment\Autoloader::loader');
     Shop::setContext(ShopCore::CONTEXT_ALL);
     $installer = new \AdyenPayment\Classes\Utility\Installer($module);
 


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When trying to update the module from a version prior to 5.2.0 I got an error that the Autoloader class was already in use because another module was using the same class name.

## Tested scenarios
Having an Adyen version prior to 5.2.0 with the Doofinder module, which is the one we have detected the conflict with.

When trying to update Adyen to the latest version, the error occurred.
"Cannot declare class Autoloader, because the name is already in use"

